### PR TITLE
Handle unable to crawl

### DIFF
--- a/app/church-finder/components/church-discovery-panel.tsx
+++ b/app/church-finder/components/church-discovery-panel.tsx
@@ -56,10 +56,10 @@ export function ChurchDiscoveryPanel({ onChurchCreated, onChurchView }: ChurchDi
     const timers: NodeJS.Timeout[] = [];
 
     if (evaluationStatus === "fetching") {
-      // Move to analyzing after 12 seconds (realistic crawl time)
+      // Move to analyzing after 15 seconds (realistic crawl time)
       const timer = setTimeout(() => {
         setEvaluationStatus((prev) => (prev === "fetching" ? "analyzing" : prev));
-      }, 12000);
+      }, 15000);
       timers.push(timer);
     }
 

--- a/app/church-finder/components/church-discovery-panel.tsx
+++ b/app/church-finder/components/church-discovery-panel.tsx
@@ -30,6 +30,8 @@ type ChurchDiscoveryPanelProps = {
   onChurchView: (church: ChurchDetail) => void;
 };
 
+const CRAWL_STATUS_TRANSITION_TIMEOUT = 15000;
+
 export function ChurchDiscoveryPanel({ onChurchCreated, onChurchView }: ChurchDiscoveryPanelProps) {
   const { user } = useAuth();
   const [city, setCity] = useState("");
@@ -59,7 +61,7 @@ export function ChurchDiscoveryPanel({ onChurchCreated, onChurchView }: ChurchDi
       // Move to analyzing after 15 seconds (realistic crawl time)
       const timer = setTimeout(() => {
         setEvaluationStatus((prev) => (prev === "fetching" ? "analyzing" : prev));
-      }, 15000);
+      }, CRAWL_STATUS_TRANSITION_TIMEOUT);
       timers.push(timer);
     }
 
@@ -172,7 +174,7 @@ export function ChurchDiscoveryPanel({ onChurchCreated, onChurchView }: ChurchDi
     // Set up progress simulation for this specific church
     const fetchingTimer = setTimeout(() => {
       setSearchEvaluationStatuses((prev) => new Map(prev).set(result.id, "analyzing"));
-    }, 15000);
+    }, CRAWL_STATUS_TRANSITION_TIMEOUT);
 
     try {
       // Check if church already exists

--- a/lib/prompts/church-finder.ts
+++ b/lib/prompts/church-finder.ts
@@ -227,7 +227,7 @@ export const DENOMINATION_CONFESSION_PROMPT = `${COMMON_RULES}
 ### Task: Identify Denomination, Confession, and Structural Characteristics
 
 **Denomination:**
-- \`label\`: Best guess of denomination (e.g., "Reformed Baptist", "Presbyterian (PCA)", "Lutheran (LCMS)", "Anglican", "Non-denominational", etc.)
+- \`label\`: Best guess of denomination (e.g., "Reformed Baptist", "Presbyterian (PCA)", "Baptist (SBC affiliated)", "Lutheran (LCMS)", "Anglican", "Non-denominational", etc.)
 - \`confidence\`: 0.0 to 1.0 (how confident are you?)
 - \`signals\`: Array of short reasons (e.g., ["credo-baptism", "elder-led", "WCF referenced"])
 
@@ -291,6 +291,7 @@ Determine if the church **adopts** a historic confession as their doctrinal stan
 - If the site uses qualifying language (e.g., "subscribe for guidance but not absolute adherence", "subscribe for guidance", "affirm as sound teaching"), still mark \`adopted = true\` because the confession is being presented as the church's doctrinal guide. In this case, add a clarifying note that preserves the nuance (see Notes below).
 
 **CRITICAL REJECTIONS - Mark \`adopted = false\` for these:**
+- Baptist Faith and Message (2000 Edition / BFM 2000) - Southern Baptist Convention statement, NOT a historic Reformed confession. While biblically sound, it accommodates both Reformed and Arminian soteriology within the SBC. **Special handling:** Set \`name\` to "Baptist Faith and Message (2000 Edition)", note in denomination field as "Baptist (SBC affiliated/BFM 2000)", and mark \`adopted = false\`. This allows doctrine inference while preventing the Reformed badge.
 - ECO Essential Tenets (2012) - Modern progressive confession, NOT historic Reformed
 - Book of Confessions (PCUSA/ECO collection) - Contains problematic modern confessions (Confession of 1967, Belhar)
 - Any confession not explicitly listed above

--- a/lib/references/confessions_map.json
+++ b/lib/references/confessions_map.json
@@ -32,12 +32,12 @@
   "Baptist Faith and Message (2000 Edition)": {
     "baptism": "Believer's baptism by immersion",
     "governance": "Congregational",
-    "lords_supper": "Memorial/symbolic",
-    "gifts": "Continuationist",
+    "lords_supper": "Memorial",
+    "gifts": "Ambiguous/not stated",
     "sanctification": "Positional & Progressive",
-    "continuity": "Mixed/Not specified",
+    "continuity": "Ambiguous/not stated",
     "security": "Perseverance of the saints",
-    "atonement_model": "Penal substitution"
+    "atonement_model": "Substitutionary atonement (unspecified)"
   },
   "Belgic Confession (1561) + Heidelberg Catechism (1563) + Canons of Dort (1619)": {
     "baptism": "Infant (paedo)",

--- a/lib/references/confessions_map.json
+++ b/lib/references/confessions_map.json
@@ -29,6 +29,16 @@
     "security": "Perseverance of the saints",
     "atonement_model": "Penal substitution"
   },
+  "Baptist Faith and Message (2000 Edition)": {
+    "baptism": "Believer's baptism by immersion",
+    "governance": "Congregational",
+    "lords_supper": "Memorial/symbolic",
+    "gifts": "Continuationist",
+    "sanctification": "Positional & Progressive",
+    "continuity": "Mixed/Not specified",
+    "security": "Perseverance of the saints",
+    "atonement_model": "Penal substitution"
+  },
   "Belgic Confession (1561) + Heidelberg Catechism (1563) + Canons of Dort (1619)": {
     "baptism": "Infant (paedo)",
     "governance": "Presbyterian",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "calvinist-parrot",
       "version": "0.5.2",
       "dependencies": {
-        "@google/genai": "^1.27.0",
+        "@google/genai": "^1.34.0",
         "@langchain/community": "^1.0.6",
         "@langchain/core": "^1.0.2",
         "@langchain/langgraph": "^1.0.1",
@@ -95,7 +95,6 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.27.3.tgz",
       "integrity": "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -111,7 +110,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -120,8 +118,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -154,6 +151,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -411,7 +409,6 @@
       "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.6.0.tgz",
       "integrity": "sha512-83iXP5D7xMm8Wyn66TUaUrgoByCmAJuoMoZQI3sGg3JAiMlTfnCIMqyVBoNSaItaPIkaCnrsj6LiusmXV2X9YA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -427,7 +424,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -436,8 +432,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@browserbasehq/stagehand": {
       "version": "1.14.0",
@@ -507,7 +502,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.2.tgz",
       "integrity": "sha512-zfWWa+V2ViDCY/cmUfRqeWY1yLto+EpxjXnZzenB1TyxsTiXaTWeZFIZw6mac52BsuQm0RjCnisjBtdBaXOI6w==",
       "devOptional": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.6",
@@ -724,9 +720,9 @@
       "license": "MIT"
     },
     "node_modules/@google/genai": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.27.0.tgz",
-      "integrity": "sha512-sveeQqwyzO/U5kOjo3EflF1rf7v0ZGprrjPGmeT6V5u22IUTcA4wBFxW+q1n7hOX0M1iWR3944MImoNPOM+zsA==",
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.34.0.tgz",
+      "integrity": "sha512-vu53UMPvjmb7PGzlYu6Tzxso8Dfhn+a7eQFaS2uNemVtDZKwzSpJ5+ikqBbXplF7RGB1STcVDqCkPvquiwb2sw==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",
@@ -736,7 +732,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.20.1"
+        "@modelcontextprotocol/sdk": "^1.24.0"
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
@@ -906,7 +902,6 @@
       "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.4.tgz",
       "integrity": "sha512-5cVSUToeZBDEG6q3OfjuYO3yTOjI8dMsi3jgp1PGZ83hBbMeNrTA+hjT6gXPlxpTIgQeov3rSie5w7B3qzFOgg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/node": "^18.0.0",
         "extend": "3.0.2",
@@ -922,7 +917,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -931,8 +925,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",
@@ -1998,6 +1991,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.0.2.tgz",
       "integrity": "sha512-6mOn4bZyO6XT0GGrEijRtMVrmYJGZ8y1BcwyTPDptFz38lP0CEzrKEYB++h+u3TEcAd3eO25l1aGw/zVlVgw2Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -2069,6 +2063,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.0.tgz",
       "integrity": "sha512-xrclBGvNCXDmi0Nz28t3vjpxSH6UYx6w5XAXSiiB1WEdc2xD2iY/a913I3x3a31XpInUW/GGfXXfePfaghV54A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uuid": "^10.0.0"
       },
@@ -2229,9 +2224,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.7.tgz",
-      "integrity": "sha512-gpaNgUh5nftFKRkRQGnVi5dpcYSKGcZZkQffZ172OrG/XkrnS7UBTQ648YY+8ME92cC4IojpI2LqTC8sTDhAaw==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.0.tgz",
+      "integrity": "sha512-Dd23XQeFHmhf3KBW76leYVkejHlCdB7erakC2At2apL1N08Bm+dLYNP+nNHh0tzUXfPQcNcXiQyacw0PG4Fcpw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2275,9 +2270,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.7.tgz",
-      "integrity": "sha512-LlDtCYOEj/rfSnEn/Idi+j1QKHxY9BJFmxx7108A6D8K0SB+bNgfYQATPk/4LqOl4C0Wo3LACg2ie6s7xqMpJg==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.0.tgz",
+      "integrity": "sha512-onHq8dl8KjDb8taANQdzs3XmIqQWV3fYdslkGENuvVInFQzZnuBYYOG2HGHqqtvgmEU7xWzhgndXXxnhk4Z3fQ==",
       "cpu": [
         "arm64"
       ],
@@ -2291,9 +2286,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.7.tgz",
-      "integrity": "sha512-rtZ7BhnVvO1ICf3QzfW9H3aPz7GhBrnSIMZyr4Qy6boXF0b5E3QLs+cvJmg3PsTCG2M1PBoC+DANUi4wCOKXpA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.0.tgz",
+      "integrity": "sha512-Am6VJTp8KhLuAH13tPrAoVIXzuComlZlMwGr++o2KDjWiKPe3VwpxYhgV6I4gKls2EnsIMggL4y7GdXyDdJcFA==",
       "cpu": [
         "x64"
       ],
@@ -2307,9 +2302,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.7.tgz",
-      "integrity": "sha512-mloD5WcPIeIeeZqAIP5c2kdaTa6StwP4/2EGy1mUw8HiexSHGK/jcM7lFuS3u3i2zn+xH9+wXJs6njO7VrAqww==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.0.tgz",
+      "integrity": "sha512-fVicfaJT6QfghNyg8JErZ+EMNQ812IS0lmKfbmC01LF1nFBcKfcs4Q75Yy8IqnsCqH/hZwGhqzj3IGVfWV6vpA==",
       "cpu": [
         "arm64"
       ],
@@ -2323,9 +2318,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.7.tgz",
-      "integrity": "sha512-+ksWNrZrthisXuo9gd1XnjHRowCbMtl/YgMpbRvFeDEqEBd523YHPWpBuDjomod88U8Xliw5DHhekBC3EOOd9g==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.0.tgz",
+      "integrity": "sha512-TojQnDRoX7wJWXEEwdfuJtakMDW64Q7NrxQPviUnfYJvAx5/5wcGE+1vZzQ9F17m+SdpFeeXuOr6v3jbyusYMQ==",
       "cpu": [
         "arm64"
       ],
@@ -2339,9 +2334,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.7.tgz",
-      "integrity": "sha512-4WtJU5cRDxpEE44Ana2Xro1284hnyVpBb62lIpU5k85D8xXxatT+rXxBgPkc7C1XwkZMWpK5rXLXTh9PFipWsA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.0.tgz",
+      "integrity": "sha512-quhNFVySW4QwXiZkZ34SbfzNBm27vLrxZ2HwTfFFO1BBP0OY1+pI0nbyewKeq1FriqU+LZrob/cm26lwsiAi8Q==",
       "cpu": [
         "x64"
       ],
@@ -2355,9 +2350,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.7.tgz",
-      "integrity": "sha512-HYlhqIP6kBPXalW2dbMTSuB4+8fe+j9juyxwfMwCe9kQPPeiyFn7NMjNfoFOfJ2eXkeQsoUGXg+O2SE3m4Qg2w==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.0.tgz",
+      "integrity": "sha512-6JW0z2FZUK5iOVhUIWqE4RblAhUj1EwhZ/MwteGb//SpFTOHydnhbp3868gxalwea+mbOLWO6xgxj9wA9wNvNw==",
       "cpu": [
         "x64"
       ],
@@ -2371,9 +2366,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.7.tgz",
-      "integrity": "sha512-EviG+43iOoBRZg9deGauXExjRphhuYmIOJ12b9sAPy0eQ6iwcPxfED2asb/s2/yiLYOdm37kPaiZu8uXSYPs0Q==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.0.tgz",
+      "integrity": "sha512-+DK/akkAvvXn5RdYN84IOmLkSy87SCmpofJPdB8vbLmf01BzntPBSYXnMvnEEv/Vcf3HYJwt24QZ/s6sWAwOMQ==",
       "cpu": [
         "arm64"
       ],
@@ -2387,9 +2382,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.7.tgz",
-      "integrity": "sha512-gniPjy55zp5Eg0896qSrf3yB1dw4F/3s8VK1ephdsZZ129j2n6e1WqCbE2YgcKhW9hPB9TVZENugquWJD5x0ug==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.0.tgz",
+      "integrity": "sha512-Tr0j94MphimCCks+1rtYPzQFK+faJuhHWCegU9S9gDlgyOk8Y3kPmO64UcjyzZAlligeBtYZ/2bEyrKq0d2wqQ==",
       "cpu": [
         "x64"
       ],
@@ -6016,8 +6011,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
@@ -6256,6 +6250,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6266,6 +6261,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6345,6 +6341,7 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -6664,6 +6661,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7012,6 +7010,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
       "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -7065,7 +7064,6 @@
       "version": "2.8.30",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.30.tgz",
       "integrity": "sha512-aTUKW4ptQhS64+v2d6IkPzymEzzhw+G0bA1g3uBRV3+ntkH+svttKseW5IOR4Ed6NUVKqnY7qT3dKvzQ7io4AA==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -7133,6 +7131,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -7166,7 +7165,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -8042,6 +8040,7 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8343,6 +8342,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8512,6 +8512,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8833,7 +8834,6 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -8975,7 +8975,6 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
       "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-web-to-node-stream": "^3.0.0",
         "strtok3": "^6.2.4",
@@ -9714,6 +9713,7 @@
       "integrity": "sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9794,7 +9794,6 @@
       "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.4.tgz",
       "integrity": "sha512-2zqgHp3W2meNJtommmgnZdouj2dPK4AbNQ4QN7BjNpfsQhWNO4eZbUYo2iD2V3I2k9mAsCjzsM87YuE+mu8gfA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.12",
         "@types/node": "^18.19.80",
@@ -9821,7 +9820,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -9831,7 +9829,6 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -9846,8 +9843,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -9879,14 +9875,14 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "devOptional": true,
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -10457,8 +10453,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.3",
@@ -10495,6 +10490,7 @@
       "version": "1.21.6",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -10531,6 +10527,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -10667,7 +10664,6 @@
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
       "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -10690,7 +10686,6 @@
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
       "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -10702,7 +10697,6 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
       "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
@@ -10856,7 +10850,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -10904,49 +10899,44 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -10958,8 +10948,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -11688,6 +11677,7 @@
       "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "aws-ssl-profiles": "^1.1.1",
         "denque": "^2.1.0",
@@ -11774,13 +11764,15 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.0.7.tgz",
-      "integrity": "sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.1.0.tgz",
+      "integrity": "sha512-Y+KbmDbefYtHDDQKLNrmzE/YYzG2msqo2VXhzh5yrJ54tx/6TmGdkR5+kP9ma7i7LwZpZMfoY3m/AoPPPKxtVw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@next/env": "16.0.7",
+        "@next/env": "16.1.0",
         "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -11792,14 +11784,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.0.7",
-        "@next/swc-darwin-x64": "16.0.7",
-        "@next/swc-linux-arm64-gnu": "16.0.7",
-        "@next/swc-linux-arm64-musl": "16.0.7",
-        "@next/swc-linux-x64-gnu": "16.0.7",
-        "@next/swc-linux-x64-musl": "16.0.7",
-        "@next/swc-win32-arm64-msvc": "16.0.7",
-        "@next/swc-win32-x64-msvc": "16.0.7",
+        "@next/swc-darwin-arm64": "16.1.0",
+        "@next/swc-darwin-x64": "16.1.0",
+        "@next/swc-linux-arm64-gnu": "16.1.0",
+        "@next/swc-linux-arm64-musl": "16.1.0",
+        "@next/swc-linux-x64-gnu": "16.1.0",
+        "@next/swc-linux-x64-musl": "16.1.0",
+        "@next/swc-win32-arm64-msvc": "16.1.0",
+        "@next/swc-win32-x64-msvc": "16.1.0",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {
@@ -12088,6 +12080,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.96.0.tgz",
       "integrity": "sha512-dKoW56i02Prv2XQolJ9Rl9Svqubqkzg3QpwEOBuSVZLk05Shelu7s+ErRTwFc1Bs3JZ2qBqBfVpXQiJhwOGG8A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -12349,7 +12342,6 @@
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
       "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -12370,6 +12362,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -12531,7 +12524,6 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -12549,7 +12541,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -12581,6 +12572,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -12785,6 +12777,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.1.0",
         "@prisma/dev": "0.15.0",
@@ -12817,7 +12810,6 @@
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -12882,7 +12874,6 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -12919,8 +12910,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -12957,6 +12947,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12966,6 +12957,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12976,7 +12968,8 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -13022,6 +13015,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -13122,7 +13116,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -13139,7 +13132,6 @@
       "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
       "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^4.7.0"
       },
@@ -13202,7 +13194,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -13336,8 +13329,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/reselect": {
       "version": "5.1.1",
@@ -13393,7 +13385,6 @@
       "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-2.6.0.tgz",
       "integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=10.7.0"
       },
@@ -13834,7 +13825,6 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -14082,7 +14072,6 @@
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
       "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "peek-readable": "^4.1.0"
@@ -14187,6 +14176,7 @@
       "version": "3.4.15",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.15.tgz",
       "integrity": "sha512-r4MeXnfBmSOuKUWmXe6h2CcyfzJCEk4F0pptO5jlnYSIViUkVmsawj80N5h2lO3gwcmSb4n3PuN+e+GC1Guylw==",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14305,7 +14295,6 @@
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
       "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
@@ -14496,6 +14485,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14651,7 +14641,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -14701,7 +14690,6 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -15222,7 +15210,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
       "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@google/genai": "^1.27.0",
+    "@google/genai": "^1.34.0",
     "@langchain/community": "^1.0.6",
     "@langchain/core": "^1.0.2",
     "@langchain/langgraph": "^1.0.1",

--- a/utils/churchEvaluation.ts
+++ b/utils/churchEvaluation.ts
@@ -247,20 +247,17 @@ export async function extractChurchEvaluation(website: string): Promise<ChurchEv
     /doctrine/i,
     /what[_-]?we[_-]?believe/i,
     /confession/i,
-    /faith/i,
+    /\bfaith\b/i,
   ];
 
   const beliefsCandidates = pages
-    .filter((page) => {
-      const url = page.url ?? "";
-      return beliefUrlPatterns.some((pattern) => pattern.test(url));
-    })
-    .map((page) => page.url!)
-    .filter(Boolean);
+    .map((page) => page.url?.trim())
+    .filter((url): url is string => Boolean(url))
+    .filter((url) => beliefUrlPatterns.some((pattern) => pattern.test(url)));
 
   if (beliefsCandidates.length > 0) {
     // console.log(`Pre-extracting ${beliefsCandidates.length} identified beliefs pages...`);
-    
+
     try {
       const extractedBeliefs = await Promise.all(
         beliefsCandidates.map((url) =>
@@ -706,7 +703,7 @@ export function postProcessEvaluation(raw: ChurchEvaluationRaw): {
   if (falseCount > 0 || hasCriticalRedFlag) {
     status = "not_endorsed";
   }
-  // Priority 2: Low coverage (<50%) → LIMITED_INFORMATION
+  // Priority 2: Low coverage (<60%) → LIMITED_INFORMATION
   // Not enough doctrinal clarity online; encourage users to contact the church
   else if (coverageRatio < 0.6) {
     status = "limited_information";

--- a/utils/churchEvaluation.ts
+++ b/utils/churchEvaluation.ts
@@ -40,7 +40,7 @@ import { filterAllowlistedBadges } from "@/utils/badges";
 const tavilyClient = tavily({ apiKey: process.env.TAVILY_API_KEY });
 const genai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || "" });
 
-const MODEL = "gemini-3-flash-preview";
+const MODEL = "gemini-2.5-flash";
 
 // Define critical red flags that immediately make status NOT_ENDORSED
 const criticalRedFlagBadges = [

--- a/utils/confessionInference.ts
+++ b/utils/confessionInference.ts
@@ -14,9 +14,15 @@ type ConfessionKey = keyof typeof confessionsMap;
  */
 export function applyConfessionToCoreDoctrines(
   coreDoctrines: CoreDoctrineMap,
-  confessionAdopted: boolean
+  confessionAdopted: boolean,
+  confessionName?: string | null
 ): CoreDoctrineMap {
-  if (!confessionAdopted) {
+  // Special case: BF&M 2000 gets inference even when adopted=false
+  // (It's not a historic Reformed confession, but it's biblically sound)
+  const isBFM2000 = confessionName?.toLowerCase().includes("baptist faith and message") ||
+    confessionName?.toLowerCase().includes("bfm");
+
+  if (!confessionAdopted && !isBFM2000) {
     return coreDoctrines;
   }
 
@@ -41,7 +47,15 @@ export function applyConfessionToSecondary(
   confessionName: string | null,
   confessionAdopted: boolean
 ): SecondaryDoctrinesResponse["secondary"] {
-  if (!confessionAdopted || !confessionName) {
+  if (!confessionName) {
+    return secondary;
+  }
+
+  // Special case: BF&M 2000 gets inference even when adopted=false
+  const isBFM2000 = confessionName.toLowerCase().includes("baptist faith and message") ||
+    confessionName.toLowerCase().includes("bfm");
+
+  if (!confessionAdopted && !isBFM2000) {
     return secondary;
   }
 

--- a/utils/confessionInference.ts
+++ b/utils/confessionInference.ts
@@ -7,6 +7,15 @@ import { CORE_DOCTRINE_KEYS } from "@/lib/schemas/church-finder";
 
 type ConfessionKey = keyof typeof confessionsMap;
 
+function isBFM2000Confession(confessionName?: string | null): boolean {
+  const normalized = confessionName?.toLowerCase();
+  if (!normalized) return false;
+  return (
+    normalized.includes("baptist faith and message") ||
+    normalized.includes("bfm")
+  );
+}
+
 /**
  * Apply confession inference to core doctrines.
  * If a confession is adopted, mark all unknown core doctrines as "true"
@@ -19,8 +28,7 @@ export function applyConfessionToCoreDoctrines(
 ): CoreDoctrineMap {
   // Special case: BF&M 2000 gets inference even when adopted=false
   // (It's not a historic Reformed confession, but it's biblically sound)
-  const isBFM2000 = confessionName?.toLowerCase().includes("baptist faith and message") ||
-    confessionName?.toLowerCase().includes("bfm");
+  const isBFM2000 = isBFM2000Confession(confessionName);
 
   if (!confessionAdopted && !isBFM2000) {
     return coreDoctrines;
@@ -52,8 +60,7 @@ export function applyConfessionToSecondary(
   }
 
   // Special case: BF&M 2000 gets inference even when adopted=false
-  const isBFM2000 = confessionName.toLowerCase().includes("baptist faith and message") ||
-    confessionName.toLowerCase().includes("bfm");
+  const isBFM2000 = isBFM2000Confession(confessionName);
 
   if (!confessionAdopted && !isBFM2000) {
     return secondary;


### PR DESCRIPTION
This pull request introduces several improvements to the church evaluation extraction and doctrinal inference logic, with a particular focus on better handling of Southern Baptist (SBC) churches and the "Baptist Faith and Message (2000 Edition)" (BFM 2000). It also enhances the fallback extraction process for limited crawls and updates doctrinal inference rules to be more nuanced and accurate.

Key changes include:

### Improved Denomination and Confession Handling

* Updated denomination prompt to explicitly include "Baptist (SBC affiliated)" as an example, clarifying SBC identification in results.
* Added special handling in the confession prompt and logic for the "Baptist Faith and Message (2000 Edition)" (BFM 2000): it is not treated as a historic Reformed confession, but doctrinal inference is still performed when it is present, even if not formally "adopted." [[1]](diffhunk://#diff-1cc4676a3a5cda0a6289d67080af08401e7d81d22f23305d6edfdc843baf09beR294) [[2]](diffhunk://#diff-71145c9da761c2fdc5a172f7cf3fffcb06aff0575f9bec7a245c1d71b4c0a484L17-R25) [[3]](diffhunk://#diff-71145c9da761c2fdc5a172f7cf3fffcb06aff0575f9bec7a245c1d71b4c0a484L44-R58)
* Added BFM 2000 to the `confessions_map.json` with its doctrinal distinctives for accurate inference.

### Extraction Pipeline Enhancements

* Refactored the church evaluation extraction pipeline to first extract basic fields (to identify "best pages"), then use those to enrich content if the initial crawl yields limited results, and finally run parallel LLM calls on the enriched content. This improves robustness for sites with sparse content. [[1]](diffhunk://#diff-7f1349ab247357263c7df06d0f09bcb66caf84e6dea8924835bac94d948c06bfL230-R230) [[2]](diffhunk://#diff-7f1349ab247357263c7df06d0f09bcb66caf84e6dea8924835bac94d948c06bfL276-R276) [[3]](diffhunk://#diff-7f1349ab247357263c7df06d0f09bcb66caf84e6dea8924835bac94d948c06bfL286-R290) [[4]](diffhunk://#diff-7f1349ab247357263c7df06d0f09bcb66caf84e6dea8924835bac94d948c06bfL315-R379)

### Doctrinal Inference Logic

* Updated `applyConfessionToCoreDoctrines` and `applyConfessionToSecondary` to allow doctrinal inference from BFM 2000 even when it is not formally "adopted," reflecting its unique status among confessions. [[1]](diffhunk://#diff-71145c9da761c2fdc5a172f7cf3fffcb06aff0575f9bec7a245c1d71b4c0a484L17-R25) [[2]](diffhunk://#diff-71145c9da761c2fdc5a172f7cf3fffcb06aff0575f9bec7a245c1d71b4c0a484L44-R58)
* Adjusted the coverage threshold for assigning a "limited_information" status from 50% to 60%, making the evaluation more conservative when content is sparse.

### Dependency Update

* Upgraded the `@google/genai` dependency from version 1.27.0 to 1.34.0 for improved LLM support.