### PR TITLE
Church finder tweaks

### DIFF
--- a/app/api/churches/[id]/route.ts
+++ b/app/api/churches/[id]/route.ts
@@ -27,3 +27,33 @@ export async function GET(_request: Request, context: RouteParams) {
 
   return NextResponse.json(mapChurchToDetail(church));
 }
+
+export async function DELETE(request: Request, context: RouteParams) {
+  const { id } = await context.params;
+
+  if (!id) {
+    return NextResponse.json({ error: "Missing church id" }, { status: 400 });
+  }
+
+  let payload: Record<string, unknown> = {};
+  try {
+    payload = (await request.json()) as Record<string, unknown>;
+  } catch {
+    // allow empty body
+  }
+
+  const userId = typeof payload.userId === "string" ? payload.userId : "";
+  const adminId = process.env.ADMIN_ID;
+  if (!adminId || !userId || userId !== adminId) {
+    return NextResponse.json({ error: "Unauthorized: Only admins can delete churches" }, { status: 403 });
+  }
+
+  const existing = await prisma.church.findUnique({ where: { id }, select: { id: true } });
+  if (!existing) {
+    return NextResponse.json({ error: "Church not found" }, { status: 404 });
+  }
+
+  await prisma.church.delete({ where: { id } });
+
+  return NextResponse.json({ ok: true, id });
+}

--- a/app/church-finder/api.ts
+++ b/app/church-finder/api.ts
@@ -8,13 +8,13 @@ export type ChurchFilters = {
   denomination?: string | null;
   confessional?: "true" | "false" | null;
   status?:
-    | "historic_reformed"
-    | "recommended"
-    | "biblically_sound_with_differences"
-    | "limited_information"
-    | "not_endorsed"
-    | "exclude_red_flag_and_limited"
-    | null;
+  | "historic_reformed"
+  | "recommended"
+  | "biblically_sound_with_differences"
+  | "limited_information"
+  | "not_endorsed"
+  | "exclude_red_flag_and_limited"
+  | null;
 };
 
 function buildQuery(params: ChurchFilters): string {
@@ -147,4 +147,19 @@ export async function createChurch(payload: {
   }
 
   return (await response.json()) as ChurchDetail;
+}
+
+export async function deleteChurch(id: string, payload: { userId?: string } = {}): Promise<{ ok: true; id: string }> {
+  const response = await fetch(`/api/churches/${id}`, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: "Unknown error" }));
+    throw new Error(error?.error ?? "Unable to delete church");
+  }
+
+  return (await response.json()) as { ok: true; id: string };
 }

--- a/app/church-finder/page.tsx
+++ b/app/church-finder/page.tsx
@@ -219,6 +219,15 @@ function ChurchFinderClient() {
     [queryClient]
   );
 
+  const handleChurchDeleted = useCallback(
+    (churchId: string) => {
+      queryClient.removeQueries({ queryKey: ["church-detail", churchId], exact: true });
+      void queryClient.invalidateQueries({ queryKey: ["churches"], refetchType: "active" });
+      void queryClient.invalidateQueries({ queryKey: ["churches", "meta"], refetchType: "active" });
+    },
+    [queryClient]
+  );
+
   // Keep URL in sync with dialog state for shareable links (?church=<id>)
   useEffect(() => {
     const idFromParam = searchParams.get("church");
@@ -410,6 +419,7 @@ function ChurchFinderClient() {
         }}
         church={detailQuery.data ?? null}
         onChurchUpdated={handleChurchUpdated}
+        onChurchDeleted={handleChurchDeleted}
       />
     </div>
   );

--- a/lib/prompts/church-finder.ts
+++ b/lib/prompts/church-finder.ts
@@ -371,6 +371,11 @@ Add badges ONLY if you have clear evidence, including the emoji. If none of the 
 - Guaranteed physical/financial blessing for faith/giving
 - Teachers: Osteen, Copeland, Dollar, Hinn, Meyer (if heavily referenced)
 
+**CRITICAL false-positive guard for ⚠️ Prosperity Gospel**:
+- Do NOT add this badge for normal stewardship, generosity, tithing, or fundraising/capital campaign language (e.g., "Sow to Reap", "harvest", "sowing into God's work", "we met our goal", building/kids/community initiatives) unless the church explicitly teaches that giving/faith will reliably produce personal wealth/health or guarantees material blessing.
+- The mere presence of agricultural metaphors from Scripture ("sow/reap") is NOT sufficient evidence by itself.
+- If the only evidence is a giving campaign description without promises of personal enrichment, omit the badge.
+
 **⚠️ Hyper-Charismatic**: 
 - Excessive focus on manifestations
 - "Drunk in the Spirit", "holy laughter", "grave soaking"
@@ -387,16 +392,19 @@ Add badges ONLY if you have clear evidence, including the emoji. If none of the 
 - **NOTE**: Youth and children's ministries naturally use engaging methods (games, activities, creative lessons) to reach their age group. Only flag if the church's MAIN worship services show entertainment-driven compromise, not based solely on youth/children's ministry descriptions.
 
 **👩‍🏫 Ordained Women**:
-- Women serving as **pastors**, **elders**, **bishops**, **priests**, or **reverends** (senior teaching/governing roles)
-- NOT for women serving as deacons, staff, ministry leaders, or teachers in non-governing roles
-- Look for titles like: "Pastor [Woman's name]", "Elder [Woman's name]", "Rev. [Woman's name]", "Bishop [Woman's name]", "Priestess", "Female clergy"
-- Also check leadership pages for women in elder/pastor positions
-- **IMPORTANT**: If you see "[Woman's Name] - Pastor of [any ministry area]" under "Pastoral Staff" → ADD THIS BADGE
+- Add this badge ONLY when a specific individual woman is explicitly described with an ordained/clergy office title such as **Pastor**, **Elder**, **Reverend/Rev.**, **Bishop**, or **Priest**.
+- This is about the woman's *office/title*, not about general church governance language.
+- NOT for women serving as deacons/deaconesses, staff, ministry leaders/directors, committee members, board/council roles, or teachers in non-governing roles.
+- Do NOT infer this badge from phrases like "elder-led" / "elder-directed" / "elder-governed" unless the page explicitly lists women as elders.
+- Do NOT infer this badge from "Chair" / "Vice-Chair" / "Secretary" / "Treasurer" unless the page explicitly identifies that woman as an Elder/Pastor/Rev/Bishop/Priest.
+- Look for explicit titles like: "Pastor [Woman's name]", "[Woman's name] — Pastor of ___", "Elder [Woman's name]", "Rev. [Woman's name]", "Bishop [Woman's name]", "Priest [Woman's name]".
+- **IMPORTANT**: If you see "[Woman's Name] - Pastor of [any ministry area]" under "Pastoral Staff" → ADD THIS BADGE.
+- **CRITICAL false-positive guard**: If women are listed under "Deacons and Deaconesses" / "Deaconesses" / "Deaconess" (or similar) WITHOUT an Elder/Pastor/Rev/Bishop/Priest title, DO NOT add this badge.
 - Examples that MUST trigger this badge:
   - "Courtney McLaughlin - Pastor of Missions"
-  - "Sarah Johnson - Pastor of Children's Ministry"  
+  - "Sarah Johnson - Pastor of Children's Ministry"
   - "Jane Doe - Teaching Pastor"
-  - Any woman with "Pastor", "Elder", "Reverend", or "Bishop" in their official title
+  - "Elder Sarah Johnson" / "Rev. Jane Doe" / "Bishop Mary Smith"
 
 **🏳️‍🌈 LGBTQ Affirming**: 
 Look for explicit affirmation in these contexts:
@@ -457,5 +465,7 @@ For each red flag badge you add, create a note with:
 - \`label\`: Name of the badge (e.g., "Prosperity Gospel", "LGBTQ Affirming", "New Apostolic Reformation (NAR)")
 - \`text\`: Brief explanation of what you found (≤50 words)
 - \`source_url\`: URL where you found this evidence
+
+For the **👩‍🏫 Ordained Women** badge specifically, your note text MUST quote the woman's name and her explicit office title exactly as written on the site (e.g., "Sarah Johnson — Pastor of Children's Ministry"). If you cannot quote an explicit Elder/Pastor/Rev/Bishop/Priest title tied to a specific woman, DO NOT add the badge.
 
 If NO red flags are found, return empty arrays for both badges and notes.`;


### PR DESCRIPTION
This pull request implements the ability for administrators to delete churches from the Church Finder app, improves the deletion workflow in the UI, and makes several enhancements to church evaluation and badge assignment logic. The most significant changes include adding a secure API endpoint for deleting churches, updating the frontend to support deletion with proper cache invalidation, and tightening the logic and instructions for specific badge assignments.

**Church deletion feature:**

- Added a secure `DELETE` endpoint to `app/api/churches/[id]/route.ts` that allows only admins (validated via `ADMIN_ID` and `userId`) to delete churches, returning appropriate error responses for missing/unauthorized/deleted churches. ([app/api/churches/[id]/route.tsR30-R59](diffhunk://#diff-0d8d8920e5252adadfbc0aece412d93d98d11ebb8ddcf58047d4b729d4a19f19R30-R59))
- Implemented a `deleteChurch` function in `app/church-finder/api.ts` to call the new API endpoint and handle errors.
- Updated `ChurchDetailDialog` in `app/church-finder/components/church-detail-dialog.tsx` to support deletion, including a confirmation prompt, error handling, and a callback (`onChurchDeleted`) to notify parent components. [[1]](diffhunk://#diff-dc472fd1553a6435011b28e2f0eb5aa483e326a97118126855f5d4be955f678dL21-R21) [[2]](diffhunk://#diff-dc472fd1553a6435011b28e2f0eb5aa483e326a97118126855f5d4be955f678dR102-R111) [[3]](diffhunk://#diff-dc472fd1553a6435011b28e2f0eb5aa483e326a97118126855f5d4be955f678dR141-R152) [[4]](diffhunk://#diff-dc472fd1553a6435011b28e2f0eb5aa483e326a97118126855f5d4be955f678dR807-R846)
- Modified `ChurchFinderClient` in `app/church-finder/page.tsx` to handle church deletion by removing and invalidating relevant queries, ensuring the UI stays in sync after deletion. [[1]](diffhunk://#diff-a9a5ce15e06bfb777c7897d05e36bc4a5be7442627d9eb0da043a86d567e5b4eR222-R230) [[2]](diffhunk://#diff-a9a5ce15e06bfb777c7897d05e36bc4a5be7442627d9eb0da043a86d567e5b4eR422)

**Church evaluation and badge assignment enhancements:**

- Improved the extraction logic in `utils/churchEvaluation.ts` to always extract all `best_pages_for` URLs, preventing missed key information, and to replace existing page content with newly extracted data for consistency. [[1]](diffhunk://#diff-7f1349ab247357263c7df06d0f09bcb66caf84e6dea8924835bac94d948c06bfL373-R389) [[2]](diffhunk://#diff-7f1349ab247357263c7df06d0f09bcb66caf84e6dea8924835bac94d948c06bfL412-R427) [[3]](diffhunk://#diff-7f1349ab247357263c7df06d0f09bcb66caf84e6dea8924835bac94d948c06bfR444-R445)
- Fixed a minor bug in `dropAnchorDupes` by correcting the placement of a variable declaration for clarity and correctness.

**Badge assignment prompt clarifications:**

- Strengthened instructions for the ⚠️ Prosperity Gospel badge to avoid false positives from generic stewardship or fundraising language.
- Significantly clarified and tightened the requirements for the 👩‍🏫 Ordained Women badge, emphasizing the need for explicit office titles and direct quotes, and adding a critical false-positive guard. [[1]](diffhunk://#diff-1cc4676a3a5cda0a6289d67080af08401e7d81d22f23305d6edfdc843baf09beL390-R407) [[2]](diffhunk://#diff-1cc4676a3a5cda0a6289d67080af08401e7d81d22f23305d6edfdc843baf09beR469-R470)