### PR TITLE
New mobile homescreen

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,7 @@
 /* app/global.css */
 
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -7,6 +9,20 @@
 @layer utilities {
   .text-balance {
     text-wrap: balance;
+  }
+
+  .material-symbols-outlined {
+    font-family: 'Material Symbols Outlined';
+    font-weight: normal;
+    font-style: normal;
+    font-size: 24px;
+    display: inline-block;
+    line-height: 1;
+    text-transform: none;
+    letter-spacing: normal;
+    word-wrap: normal;
+    white-space: nowrap;
+    direction: ltr;
   }
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from "@/components/ui/card";
@@ -12,6 +13,7 @@ import { AppSidebar } from "@/components/chat-sidebar";
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { useUserIdentifier } from "@/hooks/use-user-identifier";
 import { useChatList } from "@/hooks/use-chat-list";
+import { BookOpen, Church } from "lucide-react";
 
 export default function MainChatPage() {
   const [initialQuestion, setInitialQuestion] = useState("");
@@ -60,29 +62,73 @@ export default function MainChatPage() {
         <header className="sticky top-0 z-20 flex h-16 shrink-0 items-center gap-2 border-b bg-background/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/60">
           <SidebarTrigger className="-ml-1" />
         </header>
-        <div className="flex flex-1 items-center justify-center overflow-y-auto px-4 py-6">
-          <Card className="w-full max-w-3xl">
-            <CardHeader>
-              <div className="flex items-center space-x-4">
-                <Image src="/Logo.png" alt="Calvinist Parrot" width={100} height={100} priority unoptimized={true} />
-                <CardTitle className="w-full justify-center text-3xl font-bold">Calvinist Parrot</CardTitle>
-              </div>
-              <CardDescription>What theological question do you have?</CardDescription>
-            </CardHeader>
-            <CardContent>
-              {errorMessage && <p className="mb-4 text-destructive">{errorMessage}</p>}
-              <form onSubmit={handleStartNewChat} className="space-y-4">
-                <Textarea
-                  placeholder="Enter your question here..."
-                  value={initialQuestion}
-                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setInitialQuestion(e.target.value)}
-                />
-                <Button type="submit" className="w-full">
-                  Start Chat
-                </Button>
-              </form>
-            </CardContent>
-          </Card>
+        <div className="relative flex flex-1 flex-col overflow-y-auto px-4">
+          <div
+            className="flex min-h-0 flex-1 items-start justify-center pb-10"
+            style={{ paddingTop: "clamp(2rem, calc((100vh - var(--app-header-height)) * 0.12), 10rem)" }}
+          >
+            <Card className="w-full max-w-3xl">
+              <CardHeader>
+                <div className="flex items-center space-x-4">
+                  <Image src="/Logo.png" alt="Calvinist Parrot" width={100} height={100} priority unoptimized={true} />
+                  <CardTitle className="w-full justify-center text-3xl font-bold">Calvinist Parrot</CardTitle>
+                </div>
+                <CardDescription>What theological question do you have?</CardDescription>
+              </CardHeader>
+              <CardContent>
+                {errorMessage && <p className="mb-4 text-destructive">{errorMessage}</p>}
+                <form onSubmit={handleStartNewChat} className="space-y-4">
+                  <Textarea
+                    placeholder="Enter your question here..."
+                    value={initialQuestion}
+                    onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setInitialQuestion(e.target.value)}
+                  />
+                  <Button type="submit" className="w-full">
+                    Start Chat
+                  </Button>
+                </form>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Feature shortcuts - positioned at bottom */}
+          <div className="flex flex-wrap justify-center gap-2 pb-6 pt-4 md:hidden">
+            <Link
+              href="/journal"
+              prefetch={false}
+              className="badge--neutral inline-flex items-center gap-1.5 px-3 py-2 text-sm transition-all hover:opacity-80"
+            >
+              <BookOpen className="h-4 w-4" />
+              <span>Journal</span>
+            </Link>
+
+            <Link
+              href="/devotional"
+              prefetch={false}
+              className="badge--neutral inline-flex items-center gap-1.5 px-3 py-2 text-sm transition-all hover:opacity-80"
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: '1rem', lineHeight: 1 }}>candle</span>
+              <span>Devotional</span>
+            </Link>
+
+            <Link
+              href="/prayer-tracker"
+              prefetch={false}
+              className="badge--neutral inline-flex items-center gap-1.5 px-3 py-2 text-sm transition-all hover:opacity-80"
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: '1rem', lineHeight: 1 }}>folded_hands</span>
+              <span>Prayer Tracker</span>
+            </Link>
+
+            <Link
+              href="/church-finder"
+              prefetch={false}
+              className="badge--neutral inline-flex items-center gap-1.5 px-3 py-2 text-sm transition-all hover:opacity-80"
+            >
+              <Church className="h-4 w-4" />
+              <span>Church Finder</span>
+            </Link>
+          </div>
         </div>
       </SidebarInset>
     </SidebarProvider>


### PR DESCRIPTION
This pull request introduces feature shortcut buttons for mobile users on the main chat page and adds support for Material Symbols icons. The shortcuts provide quick access to key features like Journal, Devotional, Prayer Tracker, and Church Finder, improving navigation and user experience on smaller screens.

**Feature additions and UI improvements:**

* Added a set of feature shortcut buttons to the bottom of the main chat page (`app/page.tsx`), visible on mobile devices, linking to Journal, Devotional, Prayer Tracker, and Church Finder. These buttons use both Lucide and Material Symbols icons for visual clarity.
* Refactored the chat page layout to use a vertically stacked flexbox, ensuring the feature shortcuts are positioned at the bottom and the main card remains centered.

**Icon and style support:**

* Imported Material Symbols font via Google Fonts in `app/globals.css` to support new icon usage.
* Added CSS for `.material-symbols-outlined` to properly display Material Symbols icons.
* Included Lucide React icons (`BookOpen`, `Church`) for use in shortcut buttons in `app/page.tsx`.