### PR TITLE
Enhancements to the prayer tracker

### DIFF
--- a/app/api/prayer-tracker/sync/route.ts
+++ b/app/api/prayer-tracker/sync/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { requireAuthenticatedUser } from "@/lib/auth";
+
+export async function GET() {
+  const { userId, errorResponse } = await requireAuthenticatedUser();
+  if (errorResponse || !userId) {
+    return errorResponse ?? NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const membership = await prisma.prayerMember.findFirst({
+    where: { appwriteUserId: userId },
+    select: { spaceId: true },
+  });
+  if (!membership) {
+    return NextResponse.json({ version: null, spaceId: null });
+  }
+
+  const { spaceId } = membership;
+
+  const [
+    space,
+    familyAgg,
+    familyRequestAgg,
+    personalAgg,
+    memberAgg,
+    familyCount,
+    familyRequestCount,
+    personalCount,
+    memberCount,
+  ] = await Promise.all([
+    prisma.prayerFamilySpace.findUnique({
+      where: { id: spaceId },
+      select: { updatedAt: true },
+    }),
+    prisma.prayerFamily.aggregate({
+      where: { spaceId },
+      _max: { updatedAt: true, lastPrayedAt: true },
+    }),
+    prisma.prayerFamilyRequest.aggregate({
+      where: { family: { spaceId } },
+      _max: { dateUpdated: true, lastPrayedAt: true },
+    }),
+    prisma.prayerPersonalRequest.aggregate({
+      where: { spaceId },
+      _max: { dateUpdated: true, lastPrayedAt: true },
+    }),
+    prisma.prayerMember.aggregate({
+      where: { spaceId },
+      _max: { joinedAt: true },
+    }),
+    prisma.prayerFamily.count({ where: { spaceId } }),
+    prisma.prayerFamilyRequest.count({ where: { family: { spaceId } } }),
+    prisma.prayerPersonalRequest.count({ where: { spaceId } }),
+    prisma.prayerMember.count({ where: { spaceId } }),
+  ]);
+
+  if (!space) {
+    return NextResponse.json(
+      { spaceId: null, version: null },
+      { headers: { "Cache-Control": "no-store" } }
+    );
+  }
+
+  const timestamps = [
+    space.updatedAt,
+    familyAgg._max.updatedAt,
+    familyAgg._max.lastPrayedAt,
+    familyRequestAgg._max.dateUpdated,
+    familyRequestAgg._max.lastPrayedAt,
+    personalAgg._max.dateUpdated,
+    personalAgg._max.lastPrayedAt,
+    memberAgg._max.joinedAt,
+  ].filter((value): value is Date => value instanceof Date);
+
+  const latest = timestamps.reduce<Date | null>(
+    (acc, current) => (acc === null || current > acc ? current : acc),
+    null
+  );
+
+  // Counts catch deletes that wouldn't move any MAX(timestamp).
+  const version = [
+    latest ? latest.toISOString() : "0",
+    familyCount,
+    familyRequestCount,
+    personalCount,
+    memberCount,
+  ].join(":");
+
+  return NextResponse.json(
+    { spaceId, version },
+    { headers: { "Cache-Control": "no-store" } }
+  );
+}

--- a/app/api/prayer-tracker/sync/route.ts
+++ b/app/api/prayer-tracker/sync/route.ts
@@ -13,7 +13,10 @@ export async function GET() {
     select: { spaceId: true },
   });
   if (!membership) {
-    return NextResponse.json({ version: null, spaceId: null });
+    return NextResponse.json(
+      { version: null, spaceId: null },
+      { headers: { "Cache-Control": "no-store" } }
+    );
   }
 
   const { spaceId } = membership;
@@ -47,7 +50,7 @@ export async function GET() {
     }),
     prisma.prayerMember.aggregate({
       where: { spaceId },
-      _max: { joinedAt: true },
+      _max: { joinedAt: true, updatedAt: true },
     }),
     prisma.prayerFamily.count({ where: { spaceId } }),
     prisma.prayerFamilyRequest.count({ where: { family: { spaceId } } }),
@@ -71,6 +74,7 @@ export async function GET() {
     personalAgg._max.dateUpdated,
     personalAgg._max.lastPrayedAt,
     memberAgg._max.joinedAt,
+    memberAgg._max.updatedAt,
   ].filter((value): value is Date => value instanceof Date);
 
   const latest = timestamps.reduce<Date | null>(

--- a/app/prayer-tracker/hooks/use-prayer-space.ts
+++ b/app/prayer-tracker/hooks/use-prayer-space.ts
@@ -58,12 +58,13 @@ export function usePrayerSpace({ user, authLoading }: UsePrayerSpaceOptions) {
   }, []);
 
   const refreshAll = useCallback(
-    async () => {
-      markSpaceLoading(user?.$id ?? "");
+    async (options?: { silent?: boolean }) => {
+      const silent = options?.silent ?? false;
+      if (!silent) markSpaceLoading(user?.$id ?? "");
       try {
         await Promise.all([loadSpace(), refreshLists()]);
       } finally {
-        markSpaceReady(user?.$id ?? "");
+        if (!silent) markSpaceReady(user?.$id ?? "");
       }
     },
     [loadSpace, markSpaceLoading, markSpaceReady, refreshLists, user]

--- a/app/prayer-tracker/hooks/use-rotation-workflow.ts
+++ b/app/prayer-tracker/hooks/use-rotation-workflow.ts
@@ -7,7 +7,7 @@ type UseRotationWorkflowOptions = {
   user: AppwriteUser | null;
   members: Member[];
   onMembersUpdate: (nextMembers: Member[]) => void;
-  refreshAll: () => Promise<void>;
+  refreshAll: (options?: { silent?: boolean }) => Promise<void>;
 };
 
 type FamilyWithAssignment = {
@@ -170,7 +170,7 @@ export function useRotationWorkflow({ user, members, onMembersUpdate, refreshAll
     }
 
     handleCancelRotation();
-    await refreshAll();
+    await refreshAll({ silent: true });
     setIsConfirming(false);
   }, [familyAssignments, handleCancelRotation, personalSelections, refreshAll, rotation, user]);
 

--- a/app/prayer-tracker/hooks/use-space-sync.ts
+++ b/app/prayer-tracker/hooks/use-space-sync.ts
@@ -18,9 +18,6 @@ export function useSpaceSync({
   onRemoteChange,
   intervalMs = DEFAULT_INTERVAL_MS,
 }: UseSpaceSyncOptions) {
-  const lastVersionRef = useRef<string | null>(null);
-  const lastSpaceIdRef = useRef<string | null>(null);
-  const seededRef = useRef(false);
   const onRemoteChangeRef = useRef(onRemoteChange);
 
   useEffect(() => {
@@ -30,11 +27,19 @@ export function useSpaceSync({
   useEffect(() => {
     if (!enabled || typeof window === "undefined") return;
 
+    // Per-cycle state — reset every time the hook is (re)enabled so a stale
+    // version from a previous session doesn't suppress the first refresh.
     let cancelled = false;
     let intervalId: ReturnType<typeof setInterval> | null = null;
+    let inFlight = false;
+    let seeded = false;
+    let lastVersion: string | null = null;
+    let lastSpaceId: string | null = null;
 
     const poll = async () => {
-      if (cancelled || document.visibilityState !== "visible") return;
+      if (cancelled || inFlight) return;
+      if (document.visibilityState !== "visible") return;
+      inFlight = true;
       try {
         const response = await fetch("/api/prayer-tracker/sync", {
           credentials: "include",
@@ -44,23 +49,31 @@ export function useSpaceSync({
         const data = (await response.json()) as SyncResponse;
         if (cancelled) return;
 
-        if (!seededRef.current) {
-          lastVersionRef.current = data.version;
-          lastSpaceIdRef.current = data.spaceId;
-          seededRef.current = true;
-          return;
+        const spaceChanged = seeded && data.spaceId !== lastSpaceId;
+        const versionChanged = seeded && data.version !== lastVersion;
+
+        // First poll always refreshes once: there's an unavoidable race window
+        // between the page's initial data load and this hook mounting, so we
+        // can't trust that the seeded version matches what's already on screen.
+        const shouldRefresh = !seeded || spaceChanged || versionChanged;
+
+        if (shouldRefresh) {
+          try {
+            await onRemoteChangeRef.current();
+          } catch {
+            // Refresh failed — leave refs untouched so the next poll retries.
+            return;
+          }
+          if (cancelled) return;
         }
 
-        const spaceChanged = data.spaceId !== lastSpaceIdRef.current;
-        const versionChanged = data.version !== lastVersionRef.current;
-
-        if (spaceChanged || versionChanged) {
-          lastVersionRef.current = data.version;
-          lastSpaceIdRef.current = data.spaceId;
-          await onRemoteChangeRef.current();
-        }
+        lastVersion = data.version;
+        lastSpaceId = data.spaceId;
+        seeded = true;
       } catch {
         // Network blips are fine — try again on the next tick.
+      } finally {
+        inFlight = false;
       }
     };
 

--- a/app/prayer-tracker/hooks/use-space-sync.ts
+++ b/app/prayer-tracker/hooks/use-space-sync.ts
@@ -1,0 +1,105 @@
+import { useEffect, useRef } from "react";
+
+type UseSpaceSyncOptions = {
+  enabled: boolean;
+  onRemoteChange: () => void | Promise<void>;
+  intervalMs?: number;
+};
+
+type SyncResponse = {
+  spaceId: string | null;
+  version: string | null;
+};
+
+const DEFAULT_INTERVAL_MS = 20_000;
+
+export function useSpaceSync({
+  enabled,
+  onRemoteChange,
+  intervalMs = DEFAULT_INTERVAL_MS,
+}: UseSpaceSyncOptions) {
+  const lastVersionRef = useRef<string | null>(null);
+  const lastSpaceIdRef = useRef<string | null>(null);
+  const seededRef = useRef(false);
+  const onRemoteChangeRef = useRef(onRemoteChange);
+
+  useEffect(() => {
+    onRemoteChangeRef.current = onRemoteChange;
+  }, [onRemoteChange]);
+
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined") return;
+
+    let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const poll = async () => {
+      if (cancelled || document.visibilityState !== "visible") return;
+      try {
+        const response = await fetch("/api/prayer-tracker/sync", {
+          credentials: "include",
+          cache: "no-store",
+        });
+        if (!response.ok) return;
+        const data = (await response.json()) as SyncResponse;
+        if (cancelled) return;
+
+        if (!seededRef.current) {
+          lastVersionRef.current = data.version;
+          lastSpaceIdRef.current = data.spaceId;
+          seededRef.current = true;
+          return;
+        }
+
+        const spaceChanged = data.spaceId !== lastSpaceIdRef.current;
+        const versionChanged = data.version !== lastVersionRef.current;
+
+        if (spaceChanged || versionChanged) {
+          lastVersionRef.current = data.version;
+          lastSpaceIdRef.current = data.spaceId;
+          await onRemoteChangeRef.current();
+        }
+      } catch {
+        // Network blips are fine — try again on the next tick.
+      }
+    };
+
+    const startInterval = () => {
+      if (intervalId !== null) return;
+      intervalId = setInterval(poll, intervalMs);
+    };
+
+    const stopInterval = () => {
+      if (intervalId === null) return;
+      clearInterval(intervalId);
+      intervalId = null;
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void poll();
+        startInterval();
+      } else {
+        stopInterval();
+      }
+    };
+
+    const handleFocus = () => {
+      void poll();
+    };
+
+    void poll();
+    if (document.visibilityState === "visible") {
+      startInterval();
+    }
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("focus", handleFocus);
+
+    return () => {
+      cancelled = true;
+      stopInterval();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", handleFocus);
+    };
+  }, [enabled, intervalMs]);
+}

--- a/app/prayer-tracker/page.tsx
+++ b/app/prayer-tracker/page.tsx
@@ -43,26 +43,22 @@ function PrayerTrackerContent() {
   const [familyDetailDialogOpen, setFamilyDetailDialogOpen] = useState(false);
   const [selectedFamilyForDetail, setSelectedFamilyForDetail] = useState<Family | null>(null);
 
-  // Tab state synced with URL for browser history support. We also hold a
-  // short-lived local override so the click feels instant even if router.push
-  // is delayed by a Suspense boundary or in-flight render. The override is
-  // cleared during render whenever the URL changes (covers both our own push
-  // and back/forward navigation).
+  // Tab state synced with URL for browser history support. A short-lived
+  // local override makes clicks feel instant even if router.push is delayed
+  // by a Suspense boundary. We track the urlTab seen on the click so the
+  // override is automatically ignored once the URL moves to anything else
+  // (covers both our own push catching up and back/forward navigation),
+  // which lets us derive activeTab without an effect-driven reset.
   const router = useRouter();
   const searchParams = useSearchParams();
   const urlTab = searchParams.get("tab") || "overview";
-  const [pendingTab, setPendingTab] = useState<string | null>(null);
-  const [prevUrlTab, setPrevUrlTab] = useState(urlTab);
-  if (urlTab !== prevUrlTab) {
-    setPrevUrlTab(urlTab);
-    setPendingTab(null);
-  }
-  const activeTab = pendingTab ?? urlTab;
+  const [pendingTab, setPendingTab] = useState<{ value: string; from: string } | null>(null);
+  const activeTab = pendingTab && pendingTab.from === urlTab ? pendingTab.value : urlTab;
 
   const handleTabChange = useCallback((value: string) => {
-    setPendingTab(value);
+    setPendingTab({ value, from: urlTab });
     router.push(`/prayer-tracker?tab=${value}`, { scroll: false });
-  }, [router]);
+  }, [router, urlTab]);
 
   // Rotation card lives in client-only state, so a refresh of the lists alone
   // would leave the other household member staring at a stale prepared

--- a/app/prayer-tracker/page.tsx
+++ b/app/prayer-tracker/page.tsx
@@ -22,6 +22,7 @@ import { usePrayerSpace } from "./hooks/use-prayer-space";
 import { useFamilyManager } from "./hooks/use-family-manager";
 import { useRequestManager } from "./hooks/use-request-manager";
 import { useRotationWorkflow } from "./hooks/use-rotation-workflow";
+import { useSpaceSync } from "./hooks/use-space-sync";
 
 function PrayerTrackerContent() {
   const { user, loading: authLoading } = useAuth();
@@ -42,14 +43,41 @@ function PrayerTrackerContent() {
   const [familyDetailDialogOpen, setFamilyDetailDialogOpen] = useState(false);
   const [selectedFamilyForDetail, setSelectedFamilyForDetail] = useState<Family | null>(null);
 
-  // Tab state synced with URL for proper browser history support
+  // Tab state synced with URL for browser history support. We also hold a
+  // short-lived local override so the click feels instant even if router.push
+  // is delayed by a Suspense boundary or in-flight render. The override is
+  // cleared during render whenever the URL changes (covers both our own push
+  // and back/forward navigation).
   const router = useRouter();
   const searchParams = useSearchParams();
-  const activeTab = searchParams.get("tab") || "overview";
+  const urlTab = searchParams.get("tab") || "overview";
+  const [pendingTab, setPendingTab] = useState<string | null>(null);
+  const [prevUrlTab, setPrevUrlTab] = useState(urlTab);
+  if (urlTab !== prevUrlTab) {
+    setPrevUrlTab(urlTab);
+    setPendingTab(null);
+  }
+  const activeTab = pendingTab ?? urlTab;
 
   const handleTabChange = useCallback((value: string) => {
+    setPendingTab(value);
     router.push(`/prayer-tracker?tab=${value}`, { scroll: false });
   }, [router]);
+
+  // Rotation card lives in client-only state, so a refresh of the lists alone
+  // would leave the other household member staring at a stale prepared
+  // rotation. Cancel it so they see the fresh state and can re-prepare if
+  // they want to keep going.
+  const cancelRotation = rotationWorkflow.handleCancelRotation;
+  const handleRemoteChange = useCallback(async () => {
+    cancelRotation();
+    await refreshAll({ silent: true });
+  }, [cancelRotation, refreshAll]);
+
+  useSpaceSync({
+    enabled: Boolean(user) && isCurrentUserSpaceLoaded,
+    onRemoteChange: handleRemoteChange,
+  });
 
   const memberNames = useMemo(() => {
     const names = members.map((member) => member.displayName).join(" & ");

--- a/components/providers/app-providers.tsx
+++ b/components/providers/app-providers.tsx
@@ -4,6 +4,7 @@ import { ReactQueryProvider } from "./react-query-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { AuthProvider } from "@/hooks/use-auth";
 import { HeaderConfigProvider } from "./header-config-provider";
+import { DialogPointerEventsGuard } from "./dialog-pointer-events-guard";
 import type { ReactNode } from "react";
 
 export function AppProviders({ children }: { children: ReactNode }) {
@@ -17,6 +18,7 @@ export function AppProviders({ children }: { children: ReactNode }) {
           disableTransitionOnChange
         >
           <HeaderConfigProvider>
+            <DialogPointerEventsGuard />
             {children}
           </HeaderConfigProvider>
         </ThemeProvider>

--- a/components/providers/dialog-pointer-events-guard.tsx
+++ b/components/providers/dialog-pointer-events-guard.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Radix Dialog (used by shadcn Dialog and Sheet) sets `pointer-events: none`
+// on <body> while a modal dialog is open and is supposed to clear it on close.
+// Under rare race conditions (rapid open/close, unmount mid-animation) the
+// inline style is left behind, which silently breaks every click outside any
+// portaled overlay — including unrelated UI like the prayer-tracker tabs.
+// This guard watches <body> for both style mutations and portal mount/unmount,
+// and clears the leak on the next frame when no Radix dialog is open.
+export function DialogPointerEventsGuard() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const body = document.body;
+    let scheduled = false;
+
+    const clearIfStuck = () => {
+      scheduled = false;
+      if (body.style.pointerEvents !== "none") return;
+      const openDialog = document.querySelector('[data-state="open"][role="dialog"]');
+      if (!openDialog) {
+        body.style.pointerEvents = "";
+      }
+    };
+
+    const schedule = () => {
+      if (scheduled) return;
+      scheduled = true;
+      requestAnimationFrame(clearIfStuck);
+    };
+
+    // Watch style changes AND childList — Radix portals dialogs into body,
+    // so unmounts surface as removedNodes even when no body style mutation fires.
+    const observer = new MutationObserver(schedule);
+    observer.observe(body, {
+      attributes: true,
+      attributeFilter: ["style"],
+      childList: true,
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return null;
+}

--- a/prisma/migrations/20260524133209_prayer_member_updated_at_and_indexes/migration.sql
+++ b/prisma/migrations/20260524133209_prayer_member_updated_at_and_indexes/migration.sql
@@ -1,0 +1,16 @@
+-- AlterTable: add updatedAt nullable, backfill from joinedAt, then enforce NOT NULL
+ALTER TABLE "prayerMember" ADD COLUMN     "updatedAt" TIMESTAMP(3);
+UPDATE "prayerMember" SET "updatedAt" = COALESCE("joinedAt", CURRENT_TIMESTAMP) WHERE "updatedAt" IS NULL;
+ALTER TABLE "prayerMember" ALTER COLUMN "updatedAt" SET NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "prayerFamily_spaceId_idx" ON "prayerFamily"("spaceId");
+
+-- CreateIndex
+CREATE INDEX "prayerFamilyRequest_familyId_idx" ON "prayerFamilyRequest"("familyId");
+
+-- CreateIndex
+CREATE INDEX "prayerMember_spaceId_idx" ON "prayerMember"("spaceId");
+
+-- CreateIndex
+CREATE INDEX "prayerPersonalRequest_spaceId_idx" ON "prayerPersonalRequest"("spaceId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,12 +87,15 @@ model prayerMember {
   assignmentCapacity Int               @default(2)
   assignmentCount    Int               @default(0)
   joinedAt           DateTime          @default(now())
+  updatedAt          DateTime          @updatedAt
   lastPrayed         prayerFamily[]    @relation("LastPrayedBy")
   space              prayerFamilySpace @relation(fields: [spaceId], references: [id])
 
   // Kids Discipleship relations (Phase 3)
   annualPlans        discipleshipAnnualPlan[]    @relation("ChildAnnualPlans")
   monthlyVisions     discipleshipMonthlyVision[] @relation("ChildMonthlyVisions")
+
+  @@index([spaceId])
 }
 
 model prayerFamily {
@@ -112,6 +115,8 @@ model prayerFamily {
   lastPrayedBy         prayerMember?         @relation("LastPrayedBy", fields: [lastPrayedByMemberId], references: [id])
   space                prayerFamilySpace     @relation(fields: [spaceId], references: [id])
   requests             prayerFamilyRequest[]
+
+  @@index([spaceId])
 }
 
 model prayerFamilyRequest {
@@ -131,6 +136,7 @@ model prayerFamilyRequest {
   family               prayerFamily  @relation(fields: [familyId], references: [id])
   linkedEntry          journalEntry? @relation("FamilyRequestSource", fields: [linkedJournalEntryId], references: [id], onDelete: SetNull)
 
+  @@index([familyId])
   @@index([linkedJournalEntryId])
 }
 
@@ -153,6 +159,7 @@ model prayerPersonalRequest {
   space                prayerFamilySpace @relation(fields: [spaceId], references: [id])
   linkedEntry          journalEntry?     @relation("PersonalRequestSource", fields: [linkedJournalEntryId], references: [id], onDelete: SetNull)
 
+  @@index([spaceId])
   @@index([linkedJournalEntryId])
   @@index([subjectMemberId])
 }


### PR DESCRIPTION
This pull request introduces real-time sync and UI reliability improvements to the prayer tracker app. The most significant changes include adding a polling-based synchronization hook to detect remote changes, improving the tab switching UX, and fixing a rare UI bug caused by Radix Dialog's pointer events. There are also updates to the API and hooks to support these new features.

**Real-time sync and state updates:**

* Added a new `useSpaceSync` hook that polls the server for changes to the prayer space and triggers a refresh when remote changes are detected. This ensures all users see up-to-date data without manual refreshes. (`app/prayer-tracker/hooks/use-space-sync.ts` [[1]](diffhunk://#diff-6dcf374321269c32cef9054e3dd03d62e3100b20fe47517ad9c80f45e5a66819R1-R105) `app/prayer-tracker/page.tsx` [[2]](diffhunk://#diff-08e054bf671930f923c962ff3f46d1e332903929df0abd0957a0264e1d08c179R25) [[3]](diffhunk://#diff-08e054bf671930f923c962ff3f46d1e332903929df0abd0957a0264e1d08c179L45-R81)
* Implemented a new API endpoint (`GET /api/prayer-tracker/sync`) that returns a version string and space ID based on the latest updates and counts, enabling efficient sync checks. (`app/api/prayer-tracker/sync/route.ts` [app/api/prayer-tracker/sync/route.tsR1-R94](diffhunk://#diff-992ee9a1b23b36daa8ea75c7e5083c188404a450c0e1ccfcbde5b276b97231e4R1-R94))

**User experience improvements:**

* Enhanced tab switching in the prayer tracker with a local override for instant feedback, improving perceived responsiveness even if router navigation is delayed. (`app/prayer-tracker/page.tsx` [app/prayer-tracker/page.tsxL45-R81](diffhunk://#diff-08e054bf671930f923c962ff3f46d1e332903929df0abd0957a0264e1d08c179L45-R81))
* Updated the `refreshAll` function and related hooks to support a `silent` option, preventing unnecessary loading indicators during background syncs. (`app/prayer-tracker/hooks/use-prayer-space.ts` [[1]](diffhunk://#diff-cde3a9d740cf096878a109329c6f8f805040b2218ebc408a3d9dae975c0c1d82L61-R67) `app/prayer-tracker/hooks/use-rotation-workflow.ts` [[2]](diffhunk://#diff-dce7bbdb8c4aeced1288f6536279cf6ea6d0e60f399a61c00e32cc6ff4c2f624L10-R10) [[3]](diffhunk://#diff-dce7bbdb8c4aeced1288f6536279cf6ea6d0e60f399a61c00e32cc6ff4c2f624L173-R173)

**UI reliability fix:**

* Added a global `DialogPointerEventsGuard` component to automatically clear a rare stuck `pointer-events: none` style on `<body>` left by Radix Dialog, preventing broken UI interactions after rapid dialog open/close cycles. (`components/providers/dialog-pointer-events-guard.tsx` [[1]](diffhunk://#diff-d188263819a7a115a0b1ceb7ca54ab14a0cdd01cca78b04af7165c218c9c42c2R1-R47) `components/providers/app-providers.tsx` [[2]](diffhunk://#diff-4ef456103f6f9409926884fc1364e7148ef39297a0f8d829ef1f33744c9b31a4R7) [[3]](diffhunk://#diff-4ef456103f6f9409926884fc1364e7148ef39297a0f8d829ef1f33744c9b31a4R21)