### PR TITLE
Redesign chat experience

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -12,9 +12,8 @@ if command -v nvm >/dev/null 2>&1 && [ -f .nvmrc ]; then
 fi
 
 npm ci
-[ -f .env ] || cp .env.template .env
-
 docker compose up -d --wait postgres
+npm run db:worktree:setup
 npm run db:deploy
 npm run db:generate
 npm run db:seed

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env.worktree.local
 .env*.local
 .env
 

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+# Copied into Codex-managed worktrees before the local-environment setup runs.
+# Keep only local or staging credentials in this ignored file.
+.env.worktree.local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
 
+## Documentation Style
+
+- Do not hard-wrap Markdown prose to a fixed maximum column width. Keep each paragraph and list item on one logical line unless Markdown structure, a code block, or readability genuinely requires a line break.
+
 ## Project Overview
 
 Calvinist Parrot is an AI-powered theological assistant built with Next.js 16, React 19, and TypeScript. It combines Reformed theology with modern AI to provide biblical guidance through chat, journaling, prayer tracking, kids discipleship, and church discovery features.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ npm run dev
 
 You can also use `npm run dev:local` to start Docker, apply migrations, seed local fixtures, and launch Next.js in one command.
 
+Codex-managed worktrees share the local Postgres container but receive separate development, shadow, and test databases automatically. Put worktree-only API keys and local/staging credentials in `.env.worktree.local`; `.worktreeinclude` copies that ignored file into each new managed worktree.
+
 For the database workflow, CI/CD notes, and testing recommendations, see [Local Development](./docs/technical/Local%20Development.md).
 
 ## API Endpoints

--- a/app/[chatId]/page.tsx
+++ b/app/[chatId]/page.tsx
@@ -1,44 +1,44 @@
 "use client";
 
-import { Fragment, Suspense, useEffect, useState, useRef, useCallback } from "react";
-import { useParams, useSearchParams, useRouter } from "next/navigation";
-import Link from "next/link";
-import { AppSidebar } from "@/components/chat-sidebar";
-import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
-import { Separator } from "@/components/ui/separator";
-import { MarkdownWithBibleVerses } from "@/components/MarkdownWithBibleVerses";
-import { Loader2, Copy, Check, Info } from "lucide-react";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Card, CardContent } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
-import { useIsMobile } from "@/hooks/use-mobile";
-import { useAuth } from "@/hooks/use-auth";
-import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
-import { useChatList } from "@/hooks/use-chat-list";
-import { useQuery } from "@tanstack/react-query";
-import { fetchProfileOverview } from "@/app/profile/api";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { ArrowDown, Loader2 } from "lucide-react";
 
-// Keyed by the toolName string that arrives in tool_progress events.
-// Writer-based tools use display names (e.g. "Bible Commentary").
-// MCP/route-injected tools use LangChain names (e.g. "word_study").
+import { ChatComposer } from "@/components/chat/chat-composer";
+import { ChatShell } from "@/components/chat/chat-shell";
+import { ChatTurn } from "@/components/chat/chat-turn";
+import { DenominationContextMenu } from "@/components/chat/denomination-context-menu";
+import { EditMessageDialog } from "@/components/chat/edit-message-dialog";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAuth } from "@/hooks/use-auth";
+import { useChatList } from "@/hooks/use-chat-list";
+import {
+  groupChatMessagesIntoTurns,
+  type ChatMessageRecord,
+  type ChatTurn as ChatTurnType,
+} from "@/lib/chat-turns";
+
 const TOOL_PROGRESS_TITLES: Record<string, string> = {
-  // Display names from writer events
   "Theological Research": "Gathering supporting sources",
   "CCEL Retrieval": "Consulting classic works",
   "Memory Recall": "Recalling past context",
   "Bible Commentary": "Retrieving commentaries",
   "Cross References": "Finding cross-references",
   "Web Search": "Searching the web",
-  // LangChain tool names (from route's tools step / MCP tools)
   supplementalArticleSearch: "Gathering supporting sources",
   ccelRetrieval: "Consulting classic works",
   userMemoryRecall: "Recalling past context",
   BibleCommentary: "Retrieving commentaries",
   bibleCrossReferences: "Finding cross-references",
   generalSearch: "Searching the web",
-  // Study Bible MCP tools
   lookup_verse: "Looking up verse",
   word_study: "Analyzing word",
   get_cross_references: "Finding cross-references",
@@ -59,768 +59,771 @@ const TOOL_PROGRESS_TITLES: Record<string, string> = {
   search_by_strongs: "Searching by Strong's number",
 };
 
-const DEFAULT_DENOMINATION = "reformed-baptist";
-const DEFAULT_DENOMINATION_LABEL = "Reformed Baptist";
-const DEFAULT_DENOMINATION_REGEX = /\breformed[- ]baptist\b/i;
-const DENOMINATION_NOTICE_STORAGE_PREFIX = "chat-denomination-notice";
-
-type Message = {
-  sender: string;
-  content: string;
-  toolName?: string;
-};
-
 type Chat = {
   id: string;
   userId: string;
   conversationName: string;
+  denomination: string;
+  modifiedAt: string;
 };
 
+type RequestEvent = { requestId?: string };
+
 type DataEvent =
-  | { type: "info" | "done" }
-  | { type: "error"; stage: string; message: string }
-  | { type: "progress"; title: string; content: string }
-  | { type: "tool_progress"; toolName: string; message: string }
-  | { type: "tool_summary"; toolName: string; content: string; raw?: unknown }
-  | { type: "parrot"; content: string }
-  | { type: "calvin"; content: string }
-  | { type: "gotQuestions"; content: string }
-  | { type: "CCEL"; content: string }
-  | { type: "conversationNameUpdated"; chatId: string; name: string };
+  | ({ type: "info" | "done" | "stopped" } & RequestEvent)
+  | ({ type: "error"; stage: string; message: string } & RequestEvent)
+  | ({ type: "progress"; title: string; content: string } & RequestEvent)
+  | ({ type: "tool_progress"; toolName: string; message: string } & RequestEvent)
+  | ({
+      type: "tool_summary";
+      toolName: string;
+      content: string;
+    } & RequestEvent)
+  | ({ type: "parrot" | "calvin"; content: string } & RequestEvent)
+  | ({ type: "gotQuestions" | "CCEL"; content: string } & RequestEvent)
+  | ({
+      type: "conversationNameUpdated";
+      chatId: string;
+      name: string;
+    } & RequestEvent);
+
+type SendOptions = {
+  message?: string;
+  requestId?: string;
+  messageId?: string;
+  isAutoTrigger?: boolean;
+  retry?: boolean;
+};
 
 function ChatPageContent() {
   const params = useParams() as { chatId: string };
   const searchParams = useSearchParams();
   const router = useRouter();
-  const isMobile = useIsMobile();
   const { user } = useAuth();
+  const {
+    chats,
+    invalidate: invalidateChatList,
+    upsertChat,
+    removeChat,
+    renameChat,
+    deleteChat,
+  } = useChatList(user?.$id ?? "guest");
+
   const [chat, setChat] = useState<Chat | null>(null);
-  const [messages, setMessages] = useState<Message[]>([]);
+  const [messages, setMessages] = useState<ChatMessageRecord[]>([]);
   const [input, setInput] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
-  const [hasShownDenominationNotice, setHasShownDenominationNotice] = useState(false);
-  const [showDenominationNotice, setShowDenominationNotice] = useState(false);
-  const { chats, invalidate: invalidateChatList, upsertChat, removeChat } = useChatList(user?.$id ?? "guest");
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const [progress, setProgress] = useState<{ title: string; content: string } | null>(null);
-  const autoSentRef = useRef(false);
-  const [copiedMessageIndex, setCopiedMessageIndex] = useState<number | null>(null);
-  const copyResetTimeoutRef = useRef<number | null>(null);
-  const [isScrolled, setIsScrolled] = useState(false);
-  const lastChatScrolledRef = useRef<boolean>(false);
+  const [pageError, setPageError] = useState("");
+  const [composerError, setComposerError] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [progress, setProgress] = useState<{
+    title: string;
+    content: string;
+  } | null>(null);
+  const [showJumpToLatest, setShowJumpToLatest] = useState(false);
+  const [editingMessage, setEditingMessage] =
+    useState<ChatMessageRecord | null>(null);
+
   const messagesContainerRef = useRef<HTMLDivElement>(null);
-  // Add refs to track data loading state
-  const isFetchingChatRef = useRef(false);
-  const chatFetchedRef = useRef(false);
-  const seededInitialMessageRef = useRef(false);
-  const urlNormalizedRef = useRef(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const activeRequestRef = useRef<{ requestId: string } | null>(null);
+  const fetchControllerRef = useRef<AbortController | null>(null);
+  const fetchRetryTimeoutRef = useRef<number | null>(null);
+  const isFetchingRef = useRef(false);
+  const nearBottomRef = useRef(true);
+  const initialScrollCompleteRef = useRef(false);
+  const autoSentMessageIdRef = useRef<string | null>(null);
 
-  const initialQuestionParam = searchParams.get("initialQuestion");
-  const MAX_CHAT_FETCH_RETRIES = 5;
-  const RETRY_DELAY_BASE_MS = 200;
-  const COPY_FEEDBACK_DURATION = 2000;
-  const denominationNoticeStorageKey = `${DENOMINATION_NOTICE_STORAGE_PREFIX}:${params.chatId}`;
-
-  const profileOverview = useQuery({
-    queryKey: ["profile-overview", user?.$id ?? "guest"],
-    enabled: Boolean(user?.$id),
-    queryFn: () => fetchProfileOverview(),
-    staleTime: 1000 * 60 * 5,
-  });
-
-  const currentDenomination = profileOverview.data?.profile?.denomination ?? DEFAULT_DENOMINATION;
-  const shouldInviteDenominationChoice = !user?.$id || currentDenomination === DEFAULT_DENOMINATION;
-  const denominationMentionIndex = messages.findIndex(
-    (message) => message.sender === "parrot" && DEFAULT_DENOMINATION_REGEX.test(message.content)
+  const autoSendMessageId = searchParams.get("autoSendMessageId");
+  const turns = useMemo(
+    () => groupChatMessagesIntoTurns(messages),
+    [messages],
   );
-
-  // --- 1) Fetch Chat, User, and Chat List ---
 
   const fetchChat = useCallback(
     async (attempt = 0) => {
-      // Prevent duplicate fetch requests
-      if (isFetchingChatRef.current) return;
-
+      if (isFetchingRef.current) return;
+      isFetchingRef.current = true;
+      const fetchController = new AbortController();
+      fetchControllerRef.current = fetchController;
       try {
-        isFetchingChatRef.current = true;
-        const response = await fetch(`/api/parrot-chat?chatId=${params.chatId}`);
+        const response = await fetch(
+          `/api/parrot-chat?chatId=${encodeURIComponent(params.chatId)}`,
+          { cache: "no-store", signal: fetchController.signal },
+        );
         if (!response.ok) {
+          if (response.status === 404 && attempt < 4) {
+            fetchRetryTimeoutRef.current = window.setTimeout(() => {
+              void fetchChat(attempt + 1);
+            }, 150 * 2 ** attempt);
+            return;
+          }
           if (response.status === 403) {
-            setErrorMessage("You do not have access to this chat.");
-            return;
+            throw new Error("You do not have access to this conversation.");
           }
-          if (response.status === 404 && attempt < MAX_CHAT_FETCH_RETRIES) {
-            const delay = RETRY_DELAY_BASE_MS * Math.pow(2, attempt);
-            setTimeout(() => fetchChat(attempt + 1), delay);
-            return;
-          }
-          throw new Error("Failed to fetch chat");
+          throw new Error("We could not load this conversation.");
         }
-        const data = await response.json();
-        if (!data.chat) {
-          if (attempt < MAX_CHAT_FETCH_RETRIES) {
-            const delay = RETRY_DELAY_BASE_MS * Math.pow(2, attempt);
-            setTimeout(() => fetchChat(attempt + 1), delay);
-          } else {
-            setErrorMessage("An error occurred while fetching the chat.");
-          }
-          return;
-        }
+
+        const data = (await response.json()) as {
+          chat: Chat;
+          messages: ChatMessageRecord[];
+        };
         setChat(data.chat);
-        setMessages((current) => {
-          const incoming = Array.isArray(data.messages) ? data.messages : [];
-          // Guard against transient backend lag right after streaming.
-          // Prefer the longer transcript so the just-streamed final answer is not dropped.
-          return incoming.length >= current.length ? incoming : current;
-        });
+        setMessages(Array.isArray(data.messages) ? data.messages : []);
         upsertChat({
           id: data.chat.id,
-          conversationName: data.chat.conversationName ?? "New Conversation",
+          conversationName: data.chat.conversationName,
+          modifiedAt: data.chat.modifiedAt,
         });
-        chatFetchedRef.current = true;
-        setErrorMessage("");
-        if (initialQuestionParam && !urlNormalizedRef.current) {
-          router.replace(`/${params.chatId}`);
-          urlNormalizedRef.current = true;
-        }
+        setPageError("");
+        setIsLoading(false);
       } catch (error) {
+        if (fetchController.signal.aborted) return;
         console.error("Error fetching chat:", error);
-        if (attempt >= MAX_CHAT_FETCH_RETRIES) {
-          setErrorMessage("An error occurred while fetching the chat.");
-        }
+        setPageError(
+          error instanceof Error
+            ? error.message
+            : "We could not load this conversation.",
+        );
+        setIsLoading(false);
       } finally {
-        isFetchingChatRef.current = false;
+        if (fetchControllerRef.current === fetchController) {
+          fetchControllerRef.current = null;
+          isFetchingRef.current = false;
+        }
       }
     },
-    [params.chatId, initialQuestionParam, router, upsertChat]
+    [params.chatId, upsertChat],
   );
 
   useEffect(() => {
-    urlNormalizedRef.current = false;
-  }, [params.chatId]);
-
-  useEffect(() => {
-    setHasShownDenominationNotice(false);
-    setShowDenominationNotice(false);
-
-    if (typeof window === "undefined") return;
-
-    if (window.localStorage.getItem(denominationNoticeStorageKey) === "shown") {
-      setHasShownDenominationNotice(true);
+    fetchControllerRef.current?.abort();
+    if (fetchRetryTimeoutRef.current !== null) {
+      window.clearTimeout(fetchRetryTimeoutRef.current);
+      fetchRetryTimeoutRef.current = null;
     }
-  }, [denominationNoticeStorageKey]);
+    isFetchingRef.current = false;
+    setChat(null);
+    setMessages([]);
+    setInput("");
+    setPageError("");
+    setComposerError("");
+    setIsLoading(true);
+    setIsStreaming(false);
+    setProgress(null);
+    setShowJumpToLatest(false);
+    nearBottomRef.current = true;
+    initialScrollCompleteRef.current = false;
+    autoSentMessageIdRef.current = null;
+    void fetchChat();
 
-  useEffect(() => {
     return () => {
-      if (copyResetTimeoutRef.current !== null) {
-        window.clearTimeout(copyResetTimeoutRef.current);
+      abortControllerRef.current?.abort();
+      abortControllerRef.current = null;
+      fetchControllerRef.current?.abort();
+      fetchControllerRef.current = null;
+      isFetchingRef.current = false;
+      if (fetchRetryTimeoutRef.current !== null) {
+        window.clearTimeout(fetchRetryTimeoutRef.current);
+        fetchRetryTimeoutRef.current = null;
       }
     };
-  }, []);
+  }, [fetchChat, params.chatId]);
 
-  // Add scroll detection for both the window and the messages container (mobile Safari may scroll the window)
   useEffect(() => {
     const container = messagesContainerRef.current;
+    if (!container) return;
 
-    const computeScrolled = () => {
-      const containerScrolled = container ? container.scrollTop > 30 : false;
-      const windowScrolled = typeof window !== "undefined" ? window.scrollY > 30 : false;
-      return containerScrolled || windowScrolled;
+    const updateScrollState = () => {
+      const distanceFromBottom =
+        container.scrollHeight - container.scrollTop - container.clientHeight;
+      const isNearBottom = distanceFromBottom < 96;
+      nearBottomRef.current = isNearBottom;
+      if (isNearBottom) setShowJumpToLatest(false);
     };
 
-    const handleScroll = () => {
-      const next = computeScrolled();
-      if (next !== lastChatScrolledRef.current) {
-        lastChatScrolledRef.current = next;
-        setIsScrolled(next);
-      }
-    };
-
-    // Initialize on mount in case we land mid-scroll (e.g., browser restore)
-    setIsScrolled(computeScrolled());
-
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    if (container) container.addEventListener("scroll", handleScroll, { passive: true } as AddEventListenerOptions);
-
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-      if (container) container.removeEventListener("scroll", handleScroll);
-    };
+    container.addEventListener("scroll", updateScrollState, { passive: true });
+    return () => container.removeEventListener("scroll", updateScrollState);
   }, []);
 
-  // Load chat data once when component mounts or chatId changes
   useEffect(() => {
-    if (params.chatId && !chatFetchedRef.current) {
-      fetchChat();
-    }
-  }, [params.chatId, fetchChat]);
+    const container = messagesContainerRef.current;
+    if (!container || messages.length === 0) return;
 
-  // Seed the initial user message immediately when navigating from the landing page.
-  useEffect(() => {
-    if (!seededInitialMessageRef.current && initialQuestionParam && messages.length === 0 && !chatFetchedRef.current) {
-      seededInitialMessageRef.current = true;
-      setMessages([{ sender: "user", content: initialQuestionParam }]);
-    }
-  }, [initialQuestionParam, messages.length]);
-
-  // Scroll to bottom when messages change
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    const frame = window.requestAnimationFrame(() => {
+      if (!initialScrollCompleteRef.current || nearBottomRef.current) {
+        container.scrollTo({
+          top: container.scrollHeight,
+          behavior: initialScrollCompleteRef.current ? "auto" : "auto",
+        });
+        nearBottomRef.current = true;
+        initialScrollCompleteRef.current = true;
+        setShowJumpToLatest(false);
+      } else {
+        setShowJumpToLatest(true);
+      }
+    });
+    return () => window.cancelAnimationFrame(frame);
   }, [messages]);
 
-  useEffect(() => {
-    if (showDenominationNotice) return;
-    if (hasShownDenominationNotice) return;
-    if (denominationMentionIndex < 0) return;
-    if (!shouldInviteDenominationChoice) return;
-    if (user?.$id && profileOverview.isPending) return;
-    if (typeof window === "undefined") return;
+  const appendFailure = useCallback((requestId: string, content: string) => {
+    setMessages((current) => {
+      if (
+        current.some(
+          (message) =>
+            message.requestId === requestId && message.sender === "system_error",
+        )
+      ) {
+        return current;
+      }
+      return [
+        ...current,
+        {
+          id: `error:${requestId}`,
+          sender: "system_error",
+          content,
+          requestId,
+          timestamp: new Date().toISOString(),
+        },
+      ];
+    });
+  }, []);
 
-    window.localStorage.setItem(denominationNoticeStorageKey, "shown");
-    setHasShownDenominationNotice(true);
-    setShowDenominationNotice(true);
-  }, [
-    hasShownDenominationNotice,
-    denominationMentionIndex,
-    denominationNoticeStorageKey,
-    profileOverview.isPending,
-    shouldInviteDenominationChoice,
-    showDenominationNotice,
-    user?.$id,
-  ]);
-
-  // --- 2) Send Message ---
   const handleSendMessage = useCallback(
-    async (opts?: { message?: string; isAutoTrigger?: boolean }) => {
-      const userInput = opts?.message || input.trim();
-      if (!userInput) return;
-      setProgress({ title: "Preparing your answer", content: "Thinking through your question to give a clear reply." });
+    async (options: SendOptions = {}) => {
+      if (isStreaming) return;
+      const outgoingMessage = (options.message ?? input).trim();
+      if (!outgoingMessage) return;
 
-      // Only add user message if not auto-triggered
-      if (!opts?.isAutoTrigger) {
-        setMessages((msgs) => [...msgs, { sender: "user", content: userInput }]);
-      }
-      setInput("");
-
-      const response = await fetch("/api/parrot-chat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          chatId: params.chatId,
-          message: userInput,
-          isAutoTrigger: opts?.isAutoTrigger,
-        }),
+      const requestId = options.requestId ?? crypto.randomUUID();
+      const messageId = options.messageId ?? crypto.randomUUID();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+      activeRequestRef.current = { requestId };
+      setComposerError("");
+      setIsStreaming(true);
+      setProgress({
+        title: options.retry ? "Retrying your answer" : "Preparing your answer",
+        content: "Thinking through your question to give a clear reply.",
       });
+      nearBottomRef.current = true;
 
-      if (!response.ok || !response.body) {
-        console.error("Error processing message");
-        setProgress(null);
-        return;
+      if (options.retry) {
+        setMessages((current) =>
+          current.filter(
+            (existing) =>
+              existing.requestId !== requestId ||
+              ![
+                "tool_summary",
+                "system_error",
+                "system_stopped",
+                "parrot",
+              ].includes(existing.sender),
+          ),
+        );
+      } else if (!options.isAutoTrigger) {
+        setMessages((current) => [
+          ...current,
+          {
+            id: messageId,
+            sender: "user",
+            content: outgoingMessage,
+            requestId,
+            timestamp: new Date().toISOString(),
+          },
+        ]);
+        setInput("");
       }
 
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder("utf-8");
-      let buffer = "";
-
-      const appendToken = (sender: string, token: string) => {
-        // Skip empty tokens to prevent empty message bubbles
-        if (!token) return;
-
-        setMessages((msgs) => {
-          if (msgs.length > 0 && msgs[msgs.length - 1].sender === sender) {
-            return [...msgs.slice(0, -1), { sender, content: msgs[msgs.length - 1].content + token }];
-          } else {
-            return [...msgs, { sender, content: token }];
-          }
+      try {
+        const response = await fetch("/api/parrot-chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          signal: controller.signal,
+          body: JSON.stringify({
+            chatId: params.chatId,
+            message: outgoingMessage,
+            requestId,
+            messageId,
+            isAutoTrigger: options.isAutoTrigger,
+            retry: options.retry,
+          }),
         });
-      };
 
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) {
-          setProgress(null);
-          // When streaming is done, refresh chat without triggering a re-fetch loop
-          chatFetchedRef.current = false;
-          fetchChat();
-          // Also refresh the chat list to update the sidebar
-          invalidateChatList();
-          break;
+        if (!response.ok || !response.body) {
+          if (response.status === 409) {
+            await fetchChat();
+            return;
+          }
+          const body = (await response.json().catch(() => null)) as
+            | { error?: string }
+            | null;
+          throw new Error(body?.error || "The response could not be started.");
         }
 
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder("utf-8");
+        let buffer = "";
 
-        for (const line of lines) {
-          if (!line.trim()) continue;
-          let data: DataEvent;
-          try {
-            data = JSON.parse(line);
-          } catch (e) {
-            console.error("Failed to parse JSON line:", line, e);
-            continue;
-          }
+        const appendAssistantToken = (
+          eventRequestId: string,
+          token: string,
+          sender = "parrot",
+        ) => {
+          if (!token) return;
+          setMessages((current) => {
+            const existingIndex = current.findIndex(
+              (existing) =>
+                existing.requestId === eventRequestId &&
+                existing.sender === sender,
+            );
+            if (existingIndex < 0) {
+              return [
+                ...current,
+                {
+                  id: `stream:${eventRequestId}:${sender}`,
+                  sender,
+                  content: token,
+                  requestId: eventRequestId,
+                  timestamp: new Date().toISOString(),
+                },
+              ];
+            }
+            const next = current.slice();
+            next[existingIndex] = {
+              ...next[existingIndex],
+              content: next[existingIndex].content + token,
+            };
+            return next;
+          });
+        };
 
+        const processEvent = (data: DataEvent) => {
+          const eventRequestId = data.requestId ?? requestId;
           switch (data.type) {
             case "progress":
               setProgress({ title: data.title, content: data.content });
               break;
             case "tool_progress":
-              // Ephemeral tool progress - show in progress indicator
               setProgress({
-                title: TOOL_PROGRESS_TITLES[data.toolName] || "Working on your answer",
+                title:
+                  TOOL_PROGRESS_TITLES[data.toolName] ||
+                  "Working on your answer",
                 content: data.message,
               });
               break;
             case "tool_summary":
-              // Save tool summary as a collapsible message
-              setMessages((msgs) => [
-                ...msgs,
-                { sender: "tool_summary", content: data.content, toolName: data.toolName },
+              setMessages((current) => [
+                ...current,
+                {
+                  id: crypto.randomUUID(),
+                  sender: "tool_summary",
+                  toolName: data.toolName,
+                  content: data.content,
+                  requestId: eventRequestId,
+                  timestamp: new Date().toISOString(),
+                },
               ]);
               break;
             case "parrot":
-              appendToken("parrot", data.content);
-              break;
             case "calvin":
-              appendToken("calvin", data.content);
+              appendAssistantToken(eventRequestId, data.content, data.type);
               break;
             case "gotQuestions":
-              setMessages((msgs) => [
-                ...msgs,
-                { sender: "tool_summary", toolName: "Theological Research", content: data.content },
-              ]);
-              break;
             case "CCEL":
-              setMessages((msgs) => [
-                ...msgs,
-                { sender: "tool_summary", toolName: "CCEL Retrieval", content: data.content },
+              setMessages((current) => [
+                ...current,
+                {
+                  id: crypto.randomUUID(),
+                  sender: "tool_summary",
+                  toolName:
+                    data.type === "CCEL"
+                      ? "CCEL Retrieval"
+                      : "Theological Research",
+                  content: data.content,
+                  requestId: eventRequestId,
+                  timestamp: new Date().toISOString(),
+                },
               ]);
               break;
             case "error":
               setProgress(null);
-              setMessages((msgs) => [
-                ...msgs,
+              appendFailure(eventRequestId, data.message);
+              break;
+            case "stopped":
+              setMessages((current) => [
+                ...current,
                 {
-                  sender: "system_error",
-                  content: `An error occurred during ${data.stage}: ${data.message}`,
+                  id: `stopped:${eventRequestId}`,
+                  sender: "system_stopped",
+                  content: "Response stopped by the user.",
+                  requestId: eventRequestId,
+                  timestamp: new Date().toISOString(),
                 },
               ]);
               break;
             case "conversationNameUpdated":
-              // Update sidebar immediately with new conversation name
-              upsertChat({ id: data.chatId, conversationName: data.name });
-              if (chat?.id === data.chatId) {
-                setChat((prev) => prev ? { ...prev, conversationName: data.name } : prev);
-              }
+              upsertChat({
+                id: data.chatId,
+                conversationName: data.name,
+              });
+              setChat((current) =>
+                current?.id === data.chatId
+                  ? { ...current, conversationName: data.name }
+                  : current,
+              );
               break;
             case "done":
-              setProgress(null);
-              // Refresh chat data once after completion
-              chatFetchedRef.current = false;
-              fetchChat();
+            case "info":
+              break;
+          }
+        };
 
-              // Refresh chat list to update sidebar
-              invalidateChatList();
-              if (initialQuestionParam && !urlNormalizedRef.current) {
-                router.replace(`/${params.chatId}`);
-                urlNormalizedRef.current = true;
-              }
-              return;
-            default:
-              console.warn("Unknown event type:", data.type);
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+              processEvent(JSON.parse(line) as DataEvent);
+            } catch (error) {
+              console.error("Failed to parse chat event:", error);
+            }
           }
         }
+
+        if (buffer.trim()) {
+          try {
+            processEvent(JSON.parse(buffer) as DataEvent);
+          } catch (error) {
+            console.error("Failed to parse final chat event:", error);
+          }
+        }
+
+        await fetchChat();
+        invalidateChatList();
+      } catch (error) {
+        if (controller.signal.aborted) {
+          setMessages((current) => {
+            if (
+              current.some(
+                (message) =>
+                  message.requestId === requestId &&
+                  message.sender === "system_stopped",
+              )
+            ) {
+              return current;
+            }
+            return [
+              ...current,
+              {
+                id: `stopped:${requestId}`,
+                sender: "system_stopped",
+                content: "Response stopped by the user.",
+                requestId,
+                timestamp: new Date().toISOString(),
+              },
+            ];
+          });
+        } else {
+          console.error("Error processing message:", error);
+          const errorMessage =
+            error instanceof Error
+              ? error.message
+              : "We couldn't finish this response.";
+          setComposerError(errorMessage);
+          appendFailure(requestId, errorMessage);
+        }
+      } finally {
+        if (abortControllerRef.current === controller) {
+          abortControllerRef.current = null;
+        }
+        if (activeRequestRef.current?.requestId === requestId) {
+          activeRequestRef.current = null;
+        }
+        setProgress(null);
+        setIsStreaming(false);
       }
     },
-    [input, params.chatId, fetchChat, invalidateChatList, initialQuestionParam, router, chat?.id, upsertChat]
+    [
+      appendFailure,
+      fetchChat,
+      input,
+      invalidateChatList,
+      isStreaming,
+      params.chatId,
+      upsertChat,
+    ],
   );
 
-  // --- Auto-trigger sending if only the initial user message exists ---
   useEffect(() => {
     if (
-      chatFetchedRef.current &&
-      messages.length === 1 &&
-      messages[0].sender === "user" &&
-      !autoSentRef.current &&
-      !progress
+      !autoSendMessageId ||
+      isLoading ||
+      isStreaming ||
+      autoSentMessageIdRef.current === autoSendMessageId
     ) {
-      autoSentRef.current = true;
-      // Call handleSendMessage with autotrigger flag
-      handleSendMessage({ message: messages[0].content, isAutoTrigger: true });
+      return;
     }
-  }, [messages, handleSendMessage, progress]);
 
-  // --- 3) Rendering ---
-  if (errorMessage) {
-    return (
-      <div className="flex flex-1 overflow-hidden">
-        <p className="text-destructive">{errorMessage}</p>
-      </div>
+    const userMessage = messages.find(
+      (message) =>
+        message.id === autoSendMessageId && message.sender === "user",
     );
-  }
+    if (!userMessage) return;
 
-  if (!chat) {
-    return (
-      <SidebarProvider style={{ minHeight: "calc(100vh - var(--app-header-height))" }}>
-        <AppSidebar
-          chats={chats}
-          currentChatId={params.chatId}
-          onDeleted={(id) => {
-            removeChat(id);
-            if (id === params.chatId) {
-              router.push("/");
-            }
-          }}
-        />
-        <SidebarInset className="min-h-[calc(100vh-var(--app-header-height))] !bg-transparent">
-          <div className="flex min-h-full flex-col">
-            <header className="sticky top-0 z-20 flex h-16 shrink-0 items-center gap-2 border-b bg-background/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-              <SidebarTrigger className="-ml-1" />
-              <Separator orientation="vertical" className="h-4 mr-2" />
-              <Skeleton className="h-6 w-48" />
-            </header>
-            <div className="flex-1 overflow-hidden px-4 pb-6 pt-4">
-              <Card className="mx-auto flex h-full w-full max-w-2xl flex-col">
-                <CardContent className="flex-1 space-y-4 overflow-y-auto p-6">
-                  <p className="text-lg text-muted-foreground">Loading chat...</p>
-                  <div className="ml-auto max-w-[80%] space-y-2">
-                    <Skeleton className="h-4 w-16" />
-                    <Skeleton className="h-20 w-full" />
-                  </div>
-                  <div className="mr-auto max-w-[80%] space-y-2">
-                    <Skeleton className="h-4 w-16" />
-                    <Skeleton className="h-32 w-full" />
-                  </div>
-                </CardContent>
-                <div className="border-t bg-card/80 p-4 backdrop-blur supports-[backdrop-filter]:bg-card/60">
-                  <Skeleton className="h-20 w-full" />
-                </div>
-              </Card>
-            </div>
-          </div>
-        </SidebarInset>
-      </SidebarProvider>
+    const alreadyFinished = messages.some(
+      (message) =>
+        message.requestId === userMessage.requestId &&
+        ["parrot", "system_error", "system_stopped"].includes(message.sender),
     );
-  }
+    autoSentMessageIdRef.current = autoSendMessageId;
+    router.replace(`/${params.chatId}`);
+    if (!alreadyFinished) {
+      void handleSendMessage({
+        message: userMessage.content,
+        messageId: userMessage.id,
+        requestId: userMessage.requestId ?? crypto.randomUUID(),
+        isAutoTrigger: true,
+      });
+    }
+  }, [
+    autoSendMessageId,
+    handleSendMessage,
+    isLoading,
+    isStreaming,
+    messages,
+    params.chatId,
+    router,
+  ]);
+
+  const handleRetry = (turn: ChatTurnType) => {
+    if (!turn.requestId || !turn.user || isStreaming) return;
+    void handleSendMessage({
+      message: turn.user.content,
+      messageId: turn.user.id,
+      requestId: turn.requestId,
+      isAutoTrigger: true,
+      retry: true,
+    });
+  };
+
+  const handleCreateBranch = async (
+    message: ChatMessageRecord,
+    editedText: string,
+  ) => {
+    const response = await fetch("/api/parrot-chat/branch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sourceChatId: params.chatId,
+        sourceMessageId: message.id,
+        editedText,
+      }),
+    });
+    if (!response.ok) {
+      const body = (await response.json().catch(() => null)) as
+        | { error?: string }
+        | null;
+      throw new Error(body?.error || "Unable to create conversation branch");
+    }
+
+    const data = (await response.json()) as {
+      chatId: string;
+      title: string;
+      editedMessageId: string;
+    };
+    upsertChat({ id: data.chatId, conversationName: data.title });
+    router.push(
+      `/${data.chatId}?autoSendMessageId=${encodeURIComponent(data.editedMessageId)}`,
+    );
+  };
+
+  const jumpToLatest = () => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+    container.scrollTo({ top: container.scrollHeight, behavior: "smooth" });
+    nearBottomRef.current = true;
+    setShowJumpToLatest(false);
+  };
+
+  const stopActiveResponse = async () => {
+    const activeRequest = activeRequestRef.current;
+    abortControllerRef.current?.abort();
+    if (!activeRequest) return;
+
+    try {
+      const response = await fetch("/api/parrot-chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chatId: params.chatId,
+          requestId: activeRequest.requestId,
+          stop: true,
+        }),
+      });
+      if (!response.ok) {
+        console.error("Unable to persist stopped response state");
+      }
+    } catch (error) {
+      console.error("Unable to persist stopped response state:", error);
+    }
+  };
+
+  const currentDenomination = chat?.denomination || "reformed-baptist";
 
   return (
-    <SidebarProvider style={{ minHeight: "calc(100vh - var(--app-header-height))" }}>
-      <AppSidebar
+    <>
+      <ChatShell
         chats={chats}
         currentChatId={params.chatId}
-        onDeleted={(id) => {
-          removeChat(id);
-          if (id === params.chatId) {
-            router.push("/");
-          }
+        title={
+          isLoading ? (
+            <span
+              className="block h-5 w-48 animate-pulse rounded bg-muted motion-reduce:animate-none"
+              aria-label="Loading conversation"
+            />
+          ) : (
+            chat?.conversationName || "Conversation"
+          )
+        }
+        toolbarEnd={
+          <DenominationContextMenu
+            denomination={currentDenomination}
+            isAuthenticated={Boolean(user?.$id)}
+          />
+        }
+        onDelete={(chatId) =>
+          deleteChat.mutateAsync(chatId).then(() => undefined)
+        }
+        onRename={(chatId, conversationName) =>
+          renameChat
+            .mutateAsync({ chatId, conversationName })
+            .then(({ chat: renamedChat }) => {
+              if (renamedChat.id === params.chatId) {
+                setChat((current) =>
+                  current
+                    ? {
+                        ...current,
+                        conversationName: renamedChat.conversationName,
+                        modifiedAt: renamedChat.modifiedAt,
+                      }
+                    : current,
+                );
+              }
+            })
+        }
+        onDeleted={(chatId) => {
+          removeChat(chatId);
+          if (chatId === params.chatId) router.push("/");
         }}
-      />
-      <SidebarInset className="min-h-[calc(100vh-var(--app-header-height))] !bg-transparent">
-        <div className="flex min-h-full flex-col">
-          <header
-            className={`sticky top-[var(--app-header-height)] z-20 flex shrink-0 items-center transition-all duration-200 ease-in-out ${isMobile && isScrolled
-              ? "!bg-transparent"
-              : isScrolled
-                ? "!bg-transparent"
-                : "border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60"
-              } ${isMobile && !isScrolled ? "!bg-transparent !backdrop-blur-none" : ""}`}
-            style={{
-              height: isMobile ? (isScrolled ? "2.5rem" : "3.5rem") : isScrolled ? "3rem" : "4rem",
-              justifyContent: isMobile && isScrolled ? "center" : "flex-start",
-              paddingLeft: isMobile && isScrolled ? 0 : "1rem",
-              paddingRight: isMobile && isScrolled ? 0 : "1rem",
-            }}
+      >
+        <div className="flex h-full min-h-0 flex-col">
+          <div
+            ref={messagesContainerRef}
+            className="relative min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 py-5 scroll-smooth sm:px-6 sm:py-7"
+            aria-busy={isStreaming}
           >
-            <div
-              className={`flex items-center transition-all duration-700 ease-in-out ${isMobile && isScrolled ? "liquid-glass-pill" : ""
-                }`}
-              style={{
-                justifyContent: isMobile && isScrolled ? "center" : "flex-start",
-                background: isMobile && isScrolled ? "transparent" : "transparent",
-                backdropFilter: "none",
-                borderRadius: isMobile && isScrolled ? "9999px" : "0",
-                border: "none",
-                paddingLeft: isMobile && isScrolled ? "0.625rem" : "0",
-                paddingRight: isMobile && isScrolled ? "0.625rem" : "0",
-                paddingTop: isMobile && isScrolled ? "0.01rem" : "0",
-                paddingBottom: isMobile && isScrolled ? "0.01rem" : "0",
-                width: isMobile && isScrolled ? "50%" : "100%",
-                maxWidth: isMobile && isScrolled ? "20rem" : "none",
-                boxShadow: "none",
-                gap: isMobile && isScrolled ? 0 : "0.5rem",
-              }}
-            >
-              <SidebarTrigger
-                className="-ml-1 transition-all duration-700 ease-in-out"
-                style={{
-                  opacity: isMobile && isScrolled ? 0 : 1,
-                  width: isMobile && isScrolled ? 0 : "auto",
-                  marginLeft: isMobile && isScrolled ? 0 : undefined,
-                  marginRight: isMobile && isScrolled ? 0 : undefined,
-                  pointerEvents: isMobile && isScrolled ? "none" : "auto",
-                  transform: isMobile && isScrolled ? "scale(0)" : "scale(1)",
-                }}
-              />
-              <Separator
-                orientation="vertical"
-                className="h-4 transition-all duration-700 ease-in-out"
-                style={{
-                  opacity: isMobile && isScrolled ? 0 : 1,
-                  width: isMobile && isScrolled ? 0 : "auto",
-                  marginLeft: isMobile && isScrolled ? 0 : undefined,
-                  marginRight: isMobile && isScrolled ? 0 : "0.5rem",
-                  transform: isMobile && isScrolled ? "scale(0)" : "scale(1)",
-                }}
-              />
-              <h2
-                className="leading-tight transition-all duration-700 ease-in-out truncate"
-                style={{
-                  fontSize: isMobile ? (isScrolled ? "0.75rem" : "1rem") : isScrolled ? "0.875rem" : "1.125rem",
-                  fontWeight: isMobile && isScrolled ? 500 : 600,
-                  textAlign: isMobile && isScrolled ? "center" : "left",
-                  flex: isMobile && isScrolled ? "1" : "0 1 auto",
-                }}
-              >
-                {chat.conversationName}
-              </h2>
-            </div>
-          </header>
-          <div className="flex-1 overflow-hidden px-4 pb-6 pt-4">
-            <Card className="mx-auto flex h-full w-full max-w-2xl flex-col">
-              <CardContent ref={messagesContainerRef} className="flex-1 space-y-4 overflow-y-auto p-6">
-                {messages.map((msg, i) => {
-                  switch (msg.sender) {
-                    case "user":
-                      return (
-                        <div
-                          key={i}
-                          className="ml-auto max-w-[80%] rounded-md bg-user-message p-3 text-user-message-foreground shadow"
-                        >
-                          <div className="mb-1 text-sm font-bold">You</div>
-                          <MarkdownWithBibleVerses content={msg.content} />
-                        </div>
-                      );
-                    case "parrot":
-                      return (
-                        <Fragment key={i}>
-                          <div className="group relative mr-auto max-w-[80%] rounded-md bg-parrot-message p-3 text-parrot-message-foreground shadow break-words overflow-wrap-anywhere">
-                            <div className="mb-1 text-sm font-bold">Parrot</div>
-                            <div className="break-words overflow-wrap-anywhere">
-                              <MarkdownWithBibleVerses content={msg.content} />
-                            </div>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              aria-label={copiedMessageIndex === i ? "Markdown copied" : "Copy markdown"}
-                              className="absolute right-3 top-3 h-7 w-7 rounded-full bg-muted/30 text-muted-foreground opacity-0 shadow-sm transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:bg-muted/40"
-                              onClick={async () => {
-                                try {
-                                  await navigator.clipboard.writeText(msg.content);
-                                  setCopiedMessageIndex(i);
-                                  if (copyResetTimeoutRef.current !== null) {
-                                    window.clearTimeout(copyResetTimeoutRef.current);
-                                  }
-                                  copyResetTimeoutRef.current = window.setTimeout(() => {
-                                    setCopiedMessageIndex(null);
-                                    copyResetTimeoutRef.current = null;
-                                  }, COPY_FEEDBACK_DURATION);
-                                } catch (err) {
-                                  console.error("Failed to copy message:", err);
-                                }
-                              }}
-                            >
-                              {copiedMessageIndex === i ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-                            </Button>
-                          </div>
-
-                          {showDenominationNotice && denominationMentionIndex === i ? (
-                            <div className="mr-auto mt-2 max-w-[80%]">
-                              <Alert className="border-border/60 bg-muted/20">
-                                <Info className="h-4 w-4" />
-                                <AlertTitle>
-                                  {user?.$id ? "Prefer a different tradition?" : `Currently using ${DEFAULT_DENOMINATION_LABEL} mode`}
-                                </AlertTitle>
-                                <AlertDescription className="space-y-3">
-                                  <p>
-                                    {user?.$id
-                                      ? `Parrot is answering with ${DEFAULT_DENOMINATION_LABEL} distinctives. If you'd rather use another tradition, you can update your denomination in your profile.`
-                                      : `Parrot defaults to ${DEFAULT_DENOMINATION_LABEL} distinctives for guests. Create an account to choose another denomination, or sign in if you already have one.`}
-                                  </p>
-
-                                  <div className="flex flex-wrap gap-2">
-                                    {user?.$id ? (
-                                      <Button asChild size="sm">
-                                        <Link href="/profile">Choose denomination in profile</Link>
-                                      </Button>
-                                    ) : (
-                                      <>
-                                        <Button asChild size="sm">
-                                          <Link href="/register">Create account</Link>
-                                        </Button>
-                                        <Button asChild size="sm" variant="outline">
-                                          <Link href="/login">Sign in</Link>
-                                        </Button>
-                                      </>
-                                    )}
-                                  </div>
-                                </AlertDescription>
-                              </Alert>
-                            </div>
-                          ) : null}
-                        </Fragment>
-                      );
-                    case "calvin": // for backward compatibility
-                      return (
-                        <div key={i} className="mr-auto mt-2 max-w-[80%]">
-                          <Accordion type="single" collapsible>
-                            <AccordionItem value={`calvin-${i}`}>
-                              <AccordionTrigger>Calvin&apos;s Feedback</AccordionTrigger>
-                              <AccordionContent>
-                                <MarkdownWithBibleVerses content={msg.content} />
-                              </AccordionContent>
-                            </AccordionItem>
-                          </Accordion>
-                        </div>
-                      );
-                    case "tool_summary":
-                      const toolIcons: Record<string, string> = {
-                        "Theological Research": "🔍",
-                        "Bible Commentary": "📖",
-                        "Memory Recall": "🧠",
-                        "CCEL Retrieval": "📚",
-                        "Cross References": "🔗",
-                        "Web Search": "🌐",
-                        "Lookup Verse": "📜",
-                        "Word Study": "📘",
-                        "Get Cross References": "🔗",
-                        "Get Study Notes": "📝",
-                        "Search Lexicon": "📚",
-                        "Parse Morphology": "🔎",
-                        "Explore Genealogy": "🌿",
-                        "Explore Person Events": "👤",
-                        "Explore Place": "🗺️",
-                        "Find Connection": "🧩",
-                        "Find Similar Passages": "🧭",
-                        "Get Ane Context": "🏺",
-                        "Get Bible Dictionary": "📗",
-                        "Get Key Terms": "🏷️",
-                        "Graph Enriched Search": "🕸️",
-                        "Lookup Name": "🔤",
-                        "People In Passage": "👥",
-                        "Search By Strongs": "🔠",
-                      };
-                      const toolTitles: Record<string, string> = {
-                        "Theological Research": "Research Notes",
-                        "Bible Commentary": "Commentary References",
-                        "Memory Recall": "Context Recalled",
-                        "CCEL Retrieval": "CCEL Sources",
-                        "Cross References": "Cross-References",
-                        "Web Search": "Web Sources",
-                        "Lookup Verse": "Verse Lookup",
-                        "Word Study": "Word Study",
-                        "Get Cross References": "Cross-References",
-                        "Get Study Notes": "Study Notes",
-                        "Search Lexicon": "Lexicon Results",
-                        "Parse Morphology": "Morphology Analysis",
-                        "Explore Genealogy": "Genealogy",
-                        "Explore Person Events": "Person Events",
-                        "Explore Place": "Place Details",
-                        "Find Connection": "Passage Connections",
-                        "Find Similar Passages": "Similar Passages",
-                        "Get Ane Context": "Ancient Context",
-                        "Get Bible Dictionary": "Bible Dictionary",
-                        "Get Key Terms": "Key Terms",
-                        "Graph Enriched Search": "Knowledge Graph",
-                        "Lookup Name": "Name Lookup",
-                        "People In Passage": "People In Passage",
-                        "Search By Strongs": "Strong's Search",
-                      };
-                      const toolName = msg.toolName || "unknown";
-                      const icon = toolIcons[toolName] || "🔧";
-                      const title = toolTitles[toolName] || toolName;
-                      return (
-                        <div key={i} className="mr-auto mt-2 max-w-[80%]">
-                          <Accordion type="single" collapsible>
-                            <AccordionItem value={`tool-${i}`}>
-                              <AccordionTrigger>
-                                {icon} {title}
-                              </AccordionTrigger>
-                              <AccordionContent>
-                                <div className="max-h-72 overflow-y-auto rounded-md border border-border/60 bg-muted/20 p-3">
-                                  <MarkdownWithBibleVerses content={msg.content} />
-                                </div>
-                              </AccordionContent>
-                            </AccordionItem>
-                          </Accordion>
-                        </div>
-                      );
-                    case "system_error":
-                      return (
-                        <div key={i} className="mr-auto max-w-[80%] rounded-md border border-destructive/40 bg-destructive/10 p-3 text-destructive">
-                          <div className="mb-1 text-sm font-bold">System</div>
-                          <p className="text-sm">{msg.content}</p>
-                        </div>
-                      );
-                    default:
-                      return (
-                        <div key={i} className="mr-auto max-w-[80%] rounded-md border border-border/60 bg-muted/20 p-3 text-foreground">
-                          <div className="mb-1 text-sm font-bold">Message</div>
-                          <MarkdownWithBibleVerses content={msg.content} />
-                        </div>
-                      );
-                  }
-                })}
-                <div ref={messagesEndRef} />
-              </CardContent>
-              <div className="border-t bg-card/80 p-4 backdrop-blur supports-[backdrop-filter]:bg-card/60">
-                {progress ? (
-                  <div className="flex items-center gap-3">
-                    <Loader2 className="h-5 w-5 animate-spin text-primary" />
-                    <div className="space-y-1 text-sm">
-                      <h3 className="font-semibold leading-none">{progress.title}</h3>
-                      <p className="text-muted-foreground">{progress.content}</p>
-                    </div>
+            <div className="mx-auto w-full max-w-4xl space-y-8 pb-5">
+              {isLoading ? (
+                <div className="space-y-7" aria-label="Loading conversation">
+                  <div className="ms-auto w-3/4 max-w-xl space-y-2">
+                    <Skeleton className="h-20 w-full" />
+                    <Skeleton className="ms-auto h-8 w-36" />
                   </div>
-                ) : (
-                  <form
-                    className="flex w-full items-end gap-3"
-                    onSubmit={(e) => {
-                      e.preventDefault();
-                      handleSendMessage();
-                    }}
-                  >
-                    <Textarea
-                      className="min-h-[80px] flex-1 resize-none"
-                      placeholder="Type your message..."
-                      value={input}
-                      onChange={(e) => setInput(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" && !e.shiftKey) {
-                          e.preventDefault();
-                          handleSendMessage();
-                        }
-                      }}
-                      disabled={!!progress}
-                    />
-                    <Button type="submit" disabled={!!progress}>
-                      Send
-                    </Button>
-                  </form>
-                )}
+                  <Skeleton className="h-48 w-full max-w-[72ch]" />
+                </div>
+              ) : pageError ? (
+                <div
+                  className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive"
+                  role="alert"
+                >
+                  {pageError}
+                </div>
+              ) : turns.length === 0 ? (
+                <p className="py-12 text-center text-muted-foreground">
+                  Ask a theological question to begin.
+                </p>
+              ) : (
+                turns.map((turn) => (
+                  <ChatTurn
+                    key={turn.key}
+                    turn={turn}
+                    onEdit={setEditingMessage}
+                    onRetry={handleRetry}
+                  />
+                ))
+              )}
+            </div>
+            {showJumpToLatest ? (
+              <div className="pointer-events-none sticky bottom-3 flex justify-center">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  className="pointer-events-auto min-h-10 rounded-full border border-border shadow-lg"
+                  onClick={jumpToLatest}
+                >
+                  <ArrowDown className="h-4 w-4" aria-hidden="true" />
+                  Jump to latest
+                </Button>
               </div>
-            </Card>
+            ) : null}
+          </div>
+
+          <div className="shrink-0 border-t border-border/70 bg-background/95 px-3 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:px-6">
+            <div className="mx-auto w-full max-w-4xl">
+              {isLoading ? (
+                <div className="rounded-[var(--radius)] border bg-input-bg p-4">
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Loader2
+                      className="h-4 w-4 animate-spin motion-reduce:animate-none"
+                      aria-hidden="true"
+                    />
+                    Loading conversation…
+                  </div>
+                </div>
+              ) : (
+                <ChatComposer
+                  value={input}
+                  onChange={setInput}
+                  onSubmit={() => void handleSendMessage()}
+                  onStop={() => void stopActiveResponse()}
+                  isStreaming={isStreaming}
+                  progress={progress}
+                  error={composerError}
+                />
+              )}
+            </div>
           </div>
         </div>
-      </SidebarInset>
-    </SidebarProvider>
+      </ChatShell>
+
+      <EditMessageDialog
+        message={editingMessage}
+        open={Boolean(editingMessage)}
+        onOpenChange={(open) => {
+          if (!open) setEditingMessage(null);
+        }}
+        onConfirm={handleCreateBranch}
+      />
+      <p className="sr-only" aria-live="polite">
+        {isStreaming ? "Parrot is responding." : ""}
+      </p>
+    </>
   );
 }
 
 export default function ChatPage() {
   return (
-    <Suspense fallback={<div className="min-h-[calc(100vh-var(--app-header-height))]" />}>
+    <Suspense
+      fallback={
+        <div className="min-h-[calc(100vh-var(--app-header-height))]" />
+      }
+    >
       <ChatPageContent />
     </Suspense>
   );

--- a/app/[chatId]/page.tsx
+++ b/app/[chatId]/page.tsx
@@ -64,6 +64,7 @@ type Chat = {
   userId: string;
   conversationName: string;
   denomination: string;
+  effectiveDenomination: string;
   modifiedAt: string;
 };
 
@@ -667,13 +668,17 @@ function ChatPageContent() {
       });
       if (!response.ok) {
         console.error("Unable to persist stopped response state");
+        return;
       }
+      await fetchChat();
+      invalidateChatList();
     } catch (error) {
       console.error("Unable to persist stopped response state:", error);
     }
   };
 
-  const currentDenomination = chat?.denomination || "reformed-baptist";
+  const currentDenomination =
+    chat?.effectiveDenomination || chat?.denomination || "reformed-baptist";
 
   return (
     <>

--- a/app/api/parrot-chat/branch/route.ts
+++ b/app/api/parrot-chat/branch/route.ts
@@ -1,0 +1,138 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getChatActorId, resolveChatActor } from "@/lib/guest";
+import prisma from "@/lib/prisma";
+import { deterministicConversationTitle } from "@/lib/chat-title";
+import { selectBranchPrefix } from "@/lib/chat-turns";
+import { generateConversationName } from "@/utils/generateConversationName";
+
+const branchSchema = z.object({
+  sourceChatId: z.string().trim().min(1),
+  sourceMessageId: z.string().trim().min(1),
+  editedText: z.string().trim().min(1).max(20_000),
+});
+
+function ensureDistinctTitle(
+  generatedTitle: string,
+  sourceTitle: string,
+  editedText: string,
+) {
+  if (
+    generatedTitle.localeCompare(sourceTitle, undefined, {
+      sensitivity: "base",
+      usage: "search",
+    }) !== 0
+  ) {
+    return generatedTitle;
+  }
+
+  const fallback = deterministicConversationTitle(`user: ${editedText}`);
+  if (
+    fallback.localeCompare(sourceTitle, undefined, {
+      sensitivity: "base",
+      usage: "search",
+    }) !== 0
+  ) {
+    return fallback;
+  }
+
+  return `${fallback.slice(0, 61).trim()} — Edited`;
+}
+
+export async function POST(request: Request) {
+  const parsed = branchSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid branch request" }, { status: 400 });
+  }
+
+  const actor = await resolveChatActor();
+  const actorId = getChatActorId(actor);
+  const sourceChat = await prisma.chatHistory.findUnique({
+    where: { id: parsed.data.sourceChatId },
+  });
+
+  if (!sourceChat) {
+    return NextResponse.json({ error: "Chat not found" }, { status: 404 });
+  }
+  if (sourceChat.userId !== actorId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const sourceMessages = await prisma.chatMessage.findMany({
+    where: { chatId: sourceChat.id },
+    orderBy: [{ timestamp: "asc" }, { id: "asc" }],
+  });
+
+  let prefix;
+  try {
+    prefix = selectBranchPrefix(sourceMessages, parsed.data.sourceMessageId);
+  } catch {
+    return NextResponse.json(
+      { error: "The selected user message was not found" },
+      { status: 404 },
+    );
+  }
+
+  const namingContext = [
+    ...prefix
+      .filter((message) => message.sender === "user" || message.sender === "parrot")
+      .map((message) => `${message.sender}: ${message.content}`),
+    `user: ${parsed.data.editedText}`,
+  ].join("\n");
+  const generatedTitle = await generateConversationName(namingContext);
+  const conversationName = ensureDistinctTitle(
+    generatedTitle,
+    sourceChat.conversationName,
+    parsed.data.editedText,
+  );
+  const requestId = crypto.randomUUID();
+
+  const result = await prisma.$transaction(async (transaction) => {
+    const branchedChat = await transaction.chatHistory.create({
+      data: {
+        userId: actorId,
+        conversationName,
+        category: sourceChat.category,
+        issue_type: sourceChat.issue_type,
+        subcategory: sourceChat.subcategory,
+        denomination: sourceChat.denomination,
+      },
+    });
+
+    if (prefix.length > 0) {
+      await transaction.chatMessage.createMany({
+        data: prefix.map((message) => ({
+          chatId: branchedChat.id,
+          sender: message.sender,
+          content: message.content,
+          requestId: message.requestId,
+          timestamp: message.timestamp,
+        })),
+      });
+    }
+
+    const latestPrefixTimestampValue = prefix.at(-1)?.timestamp;
+    const latestPrefixTimestamp = latestPrefixTimestampValue
+      ? new Date(latestPrefixTimestampValue).getTime()
+      : 0;
+    const editedMessage = await transaction.chatMessage.create({
+      data: {
+        chatId: branchedChat.id,
+        sender: "user",
+        content: parsed.data.editedText,
+        requestId,
+        timestamp: new Date(Math.max(Date.now(), latestPrefixTimestamp + 1)),
+      },
+    });
+
+    return { branchedChat, editedMessage };
+  });
+
+  return NextResponse.json({
+    chatId: result.branchedChat.id,
+    title: result.branchedChat.conversationName,
+    editedMessageId: result.editedMessage.id,
+    requestId,
+  });
+}

--- a/app/api/parrot-chat/route.ts
+++ b/app/api/parrot-chat/route.ts
@@ -14,6 +14,26 @@ import { updateUserMemoriesFromConversation } from "@/utils/memoryExtraction";
 import { buildParrotSystemPrompt } from "@/utils/buildParrotSystemPrompt";
 import { getChatActorId, resolveChatActor } from "@/lib/guest";
 import { evaluateRetry } from "@/lib/chat-requests";
+import { resolveEffectiveDenomination } from "@/lib/chat-context";
+import {
+  getRequestTerminalState,
+  selectTerminalSafeMessages,
+  type RequestTerminalState,
+} from "@/lib/chat-request-state";
+
+async function withRequestPersistenceLock<T>(
+  chatId: string,
+  requestId: string,
+  operation: (tx: Prisma.TransactionClient) => Promise<T>,
+): Promise<T> {
+  return prisma.$transaction(async (tx) => {
+    const lockKey = `parrot-chat-request:${chatId}:${requestId}`;
+    await tx.$queryRaw`
+      SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))
+    `;
+    return operation(tx);
+  });
+}
 
 export async function POST(request: Request) {
   const TOOL_NODE_NAMES = new Set(["tools", ...toolsArray.map((tool) => tool.name)]);
@@ -71,38 +91,64 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const requestMessages = await prisma.chatMessage.findMany({
-      where: { chatId, requestId: resolvedRequestId },
-      select: { sender: true },
-    });
-    if (!requestMessages.some((requestMessage) => requestMessage.sender === "user")) {
-      return NextResponse.json(
-        { error: "The original request could not be found" },
-        { status: 404 },
-      );
-    }
-    if (requestMessages.some((requestMessage) => requestMessage.sender === "parrot")) {
-      return NextResponse.json({ stopped: false, completed: true });
-    }
-    if (
-      !requestMessages.some(
-        (requestMessage) => requestMessage.sender === "system_stopped",
-      )
-    ) {
-      await prisma.$transaction([
-        prisma.chatMessage.create({
+    const stopResult = await withRequestPersistenceLock(
+      chatId,
+      resolvedRequestId,
+      async (tx) => {
+        const requestMessages = await tx.chatMessage.findMany({
+          where: { chatId, requestId: resolvedRequestId },
+          select: { sender: true },
+        });
+        if (
+          !requestMessages.some(
+            (requestMessage) => requestMessage.sender === "user",
+          )
+        ) {
+          return "missing_user" as const;
+        }
+
+        const terminalState = getRequestTerminalState(requestMessages);
+        if (terminalState === "completed") {
+          return "completed" as const;
+        }
+        if (terminalState === "stopped") {
+          return "stopped" as const;
+        }
+        if (terminalState === "failed") {
+          return "failed" as const;
+        }
+
+        await tx.chatMessage.create({
           data: {
             chatId,
             requestId: resolvedRequestId,
             sender: "system_stopped",
             content: "Response stopped by the user.",
           },
-        }),
-        prisma.chatHistory.update({
+        });
+        await tx.chatHistory.update({
           where: { id: chatId },
           data: { modifiedAt: new Date() },
-        }),
-      ]);
+        });
+        return "stopped" as const;
+      },
+    );
+
+    if (stopResult === "missing_user") {
+      return NextResponse.json(
+        { error: "The original request could not be found" },
+        { status: 404 },
+      );
+    }
+    if (stopResult === "completed") {
+      return NextResponse.json({ stopped: false, completed: true });
+    }
+    if (stopResult === "failed") {
+      return NextResponse.json({
+        stopped: false,
+        completed: false,
+        failed: true,
+      });
     }
 
     return NextResponse.json({ stopped: true, completed: false });
@@ -495,13 +541,65 @@ export async function POST(request: Request) {
           });
         };
 
-        try {
+        let parrotReply = "";
+        let generationStopped = false;
+        const persistPendingMessages = () =>
+          withRequestPersistenceLock(
+            capturedChatId,
+            capturedRequestId,
+            async (tx) => {
+              const existingMessages = await tx.chatMessage.findMany({
+                where: {
+                  chatId: capturedChatId,
+                  requestId: capturedRequestId,
+                },
+                select: { sender: true },
+              });
+              const existingTerminalState =
+                getRequestTerminalState(existingMessages);
+              const stopRequested =
+                generationStopped || request.signal.aborted;
 
+              if (
+                stopRequested &&
+                !pendingMessages.some(
+                  (pendingMessage) =>
+                    pendingMessage.sender === "system_stopped",
+                )
+              ) {
+                enqueueMessage(
+                  "system_stopped",
+                  "Response stopped by the user.",
+                );
+              }
+
+              const messagesToPersist = selectTerminalSafeMessages(
+                pendingMessages,
+                existingTerminalState,
+                stopRequested,
+              );
+
+              if (messagesToPersist.length > 0) {
+                await tx.chatMessage.createMany({
+                  data: messagesToPersist,
+                });
+                await tx.chatHistory.update({
+                  where: { id: capturedChatId },
+                  data: { modifiedAt: new Date() },
+                });
+              }
+
+              return getRequestTerminalState([
+                ...existingMessages,
+                ...messagesToPersist,
+              ]);
+            },
+          );
+
+        try {
           void isAutoTrigger;
 
           // Parrot's answer
-          let parrotReply = "";
-          let generationStopped = false;
           try {
             // Build message history with system prompt (Prisma context already injected)
             const parrotHistory = buildParrotHistory(conversationMessages, newParrotSysPrompt);
@@ -702,31 +800,27 @@ export async function POST(request: Request) {
             }
           }
 
-          // Persist messages to database (without conversation naming - that's deferred)
-          if (pendingMessages.length > 0) {
+          // Stop and completion use the same transaction-scoped lock. Whichever
+          // terminal state commits first becomes authoritative for this request.
+          let persistedTerminalState: RequestTerminalState = "open";
+          try {
+            persistedTerminalState = await persistPendingMessages();
+          } catch {
+            // One short retry for transient DB pressure (e.g. P2028 timeout).
             try {
-              await prisma.chatMessage.createMany({
-                data: pendingMessages,
-              });
-              await prisma.chatHistory.update({
-                where: { id: capturedChatId },
-                data: { modifiedAt: new Date() },
-              });
-            } catch {
-              // One short retry for transient DB pressure (e.g. P2028 timeout).
-              try {
-                await wait(300);
-                await prisma.chatMessage.createMany({
-                  data: pendingMessages,
-                });
-                await prisma.chatHistory.update({
-                  where: { id: capturedChatId },
-                  data: { modifiedAt: new Date() },
-                });
-              } catch (retryError) {
-                sendError(retryError, "persist_messages", controller);
-              }
+              await wait(300);
+              persistedTerminalState = await persistPendingMessages();
+            } catch (retryError) {
+              sendError(
+                retryError,
+                "persist_messages",
+                controller,
+                capturedRequestId,
+              );
             }
+          }
+          if (persistedTerminalState === "stopped") {
+            generationStopped = true;
           }
 
           // Handle conversation naming BEFORE closing stream so client can update sidebar
@@ -738,6 +832,7 @@ export async function POST(request: Request) {
             });
 
             if (
+              persistedTerminalState === "completed" &&
               parrotReply.trim() &&
               currentChat &&
               currentChat.conversationName === "New Conversation"
@@ -787,7 +882,11 @@ export async function POST(request: Request) {
           // Memory extraction runs after stream closes since client doesn't need this data
 
           // 2. Extract and update user memories asynchronously
-          if (capturedUserId && parrotReply.trim()) {
+          if (
+            persistedTerminalState === "completed" &&
+            capturedUserId &&
+            parrotReply.trim()
+          ) {
             updateUserMemoriesFromConversation(
               capturedUserId,
               conversationMessages.map((m) => ({
@@ -797,18 +896,22 @@ export async function POST(request: Request) {
             ).catch((error) => {
               console.error("Background memory extraction failed:", error);
             });
-          } else {
+          } else if (
+            persistedTerminalState === "completed" &&
+            !capturedUserId
+          ) {
             console.warn("⚠️ Memory extraction skipped: userId is undefined");
           }
         } catch (error) {
           if (!request.signal.aborted) {
             enqueueMessage("system_error", "We couldn't finish this response.");
             if (pendingMessages.length > 0) {
-              await prisma.chatMessage.createMany({ data: pendingMessages }).catch(
-                (persistError) => {
-                  console.error("Failed to persist request failure:", persistError);
-                },
-              );
+              await persistPendingMessages().catch((persistError) => {
+                console.error(
+                  "Failed to persist request failure:",
+                  persistError,
+                );
+              });
             }
             sendError(error, "general", controller, capturedRequestId);
           }
@@ -850,10 +953,20 @@ export async function GET(request: Request) {
   if (chat.userId !== requesterUserId) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
-  const messages = await prisma.chatMessage.findMany({
-    where: { chatId },
-    orderBy: [{ timestamp: "asc" }, { id: "asc" }],
-  });
+  const [profile, messages] = await Promise.all([
+    prisma.userProfile.findUnique({
+      where: { appwriteUserId: chat.userId },
+      select: { denomination: true },
+    }),
+    prisma.chatMessage.findMany({
+      where: { chatId },
+      orderBy: [{ timestamp: "asc" }, { id: "asc" }],
+    }),
+  ]);
+  const effectiveDenomination = resolveEffectiveDenomination(
+    profile?.denomination,
+    chat.denomination,
+  );
 
   // Parse tool_summary messages from JSON strings
   const parsedMessages = messages.map((msg) => {
@@ -889,5 +1002,8 @@ export async function GET(request: Request) {
     return msg;
   });
 
-  return NextResponse.json({ chat, messages: parsedMessages });
+  return NextResponse.json({
+    chat: { ...chat, effectiveDenomination },
+    messages: parsedMessages,
+  });
 }

--- a/app/api/parrot-chat/route.ts
+++ b/app/api/parrot-chat/route.ts
@@ -13,6 +13,7 @@ import { generateConversationName } from "@/utils/generateConversationName";
 import { updateUserMemoriesFromConversation } from "@/utils/memoryExtraction";
 import { buildParrotSystemPrompt } from "@/utils/buildParrotSystemPrompt";
 import { getChatActorId, resolveChatActor } from "@/lib/guest";
+import { evaluateRetry } from "@/lib/chat-requests";
 
 export async function POST(request: Request) {
   const TOOL_NODE_NAMES = new Set(["tools", ...toolsArray.map((tool) => tool.name)]);
@@ -29,6 +30,10 @@ export async function POST(request: Request) {
     denomination?: string;
     isAutoTrigger?: boolean;
     clientChatId?: string;
+    requestId?: string;
+    messageId?: string;
+    retry?: boolean;
+    stop?: boolean;
   }
 
   const {
@@ -43,10 +48,65 @@ export async function POST(request: Request) {
     denomination = "reformed-baptist",
     isAutoTrigger,
     clientChatId,
+    requestId,
+    messageId,
+    retry = false,
+    stop = false,
   }: ChatRequestBody = await request.json();
 
-  const actor = await resolveChatActor({ externalUserId: userId });
+  void userId;
+  const actor = await resolveChatActor();
   const effectiveUserId = getChatActorId(actor);
+  const resolvedRequestId = requestId?.trim() || crypto.randomUUID();
+
+  if (chatId && stop && requestId?.trim()) {
+    const chatRecord = await prisma.chatHistory.findUnique({
+      where: { id: chatId },
+      select: { userId: true },
+    });
+    if (!chatRecord) {
+      return NextResponse.json({ error: "Chat not found" }, { status: 404 });
+    }
+    if (chatRecord.userId !== effectiveUserId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const requestMessages = await prisma.chatMessage.findMany({
+      where: { chatId, requestId: resolvedRequestId },
+      select: { sender: true },
+    });
+    if (!requestMessages.some((requestMessage) => requestMessage.sender === "user")) {
+      return NextResponse.json(
+        { error: "The original request could not be found" },
+        { status: 404 },
+      );
+    }
+    if (requestMessages.some((requestMessage) => requestMessage.sender === "parrot")) {
+      return NextResponse.json({ stopped: false, completed: true });
+    }
+    if (
+      !requestMessages.some(
+        (requestMessage) => requestMessage.sender === "system_stopped",
+      )
+    ) {
+      await prisma.$transaction([
+        prisma.chatMessage.create({
+          data: {
+            chatId,
+            requestId: resolvedRequestId,
+            sender: "system_stopped",
+            content: "Response stopped by the user.",
+          },
+        }),
+        prisma.chatHistory.update({
+          where: { id: chatId },
+          data: { modifiedAt: new Date() },
+        }),
+      ]);
+    }
+
+    return NextResponse.json({ stopped: true, completed: false });
+  }
 
   // Handle new chat from Parrot QA
   if (effectiveUserId && initialQuestion && initialAnswer && !chatId) {
@@ -66,6 +126,7 @@ export async function POST(request: Request) {
       await tx.chatMessage.create({
         data: {
           chatId: createdChat.id,
+          requestId: resolvedRequestId,
           sender: "user",
           content: initialQuestion,
         },
@@ -74,6 +135,7 @@ export async function POST(request: Request) {
       await tx.chatMessage.create({
         data: {
           chatId: createdChat.id,
+          requestId: resolvedRequestId,
           sender: "parrot",
           content: initialAnswer,
         },
@@ -82,12 +144,20 @@ export async function POST(request: Request) {
       return createdChat;
     });
 
-    return NextResponse.json({ chatId: chat.id });
+    const firstMessage = await prisma.chatMessage.findFirst({
+      where: { chatId: chat.id, requestId: resolvedRequestId, sender: "user" },
+      select: { id: true },
+    });
+    return NextResponse.json({
+      chatId: chat.id,
+      messageId: firstMessage?.id,
+      requestId: resolvedRequestId,
+    });
   }
 
   // If identity and an initial message are provided but no chatId, start a new chat session.
   if (effectiveUserId && initialQuestion && !chatId) {
-    const chat = await prisma.$transaction(async (tx) => {
+    const result = await prisma.$transaction(async (tx) => {
       const createdChat = await tx.chatHistory.create({
         data: {
           id: clientChatId ?? undefined,
@@ -100,18 +170,23 @@ export async function POST(request: Request) {
         },
       });
 
-      await tx.chatMessage.create({
+      const createdMessage = await tx.chatMessage.create({
         data: {
           chatId: createdChat.id,
+          requestId: resolvedRequestId,
           sender: "user",
           content: initialQuestion,
         },
       });
 
-      return createdChat;
+      return { createdChat, createdMessage };
     });
 
-    return NextResponse.json({ chatId: chat.id });
+    return NextResponse.json({
+      chatId: result.createdChat.id,
+      messageId: result.createdMessage.id,
+      requestId: resolvedRequestId,
+    });
   }
 
   // If chatID and message run main system <-- This continues the converation and is the main use case.
@@ -129,6 +204,64 @@ export async function POST(request: Request) {
 
     if (chatRecord.userId !== effectiveUserId) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const requestMessages = await prisma.chatMessage.findMany({
+      where: { chatId, requestId: resolvedRequestId },
+      select: { sender: true, content: true, requestId: true },
+    });
+
+    if (retry) {
+      const retryDecision = evaluateRetry(requestMessages, resolvedRequestId);
+      if (retryDecision === "already_succeeded") {
+        return NextResponse.json(
+          { error: "This request already has a successful response" },
+          { status: 409 },
+        );
+      }
+      if (retryDecision === "missing_user") {
+        return NextResponse.json(
+          { error: "The original request could not be found" },
+          { status: 404 },
+        );
+      }
+      await prisma.chatMessage.deleteMany({
+        where: {
+          chatId,
+          requestId: resolvedRequestId,
+          sender: { in: ["tool_summary", "system_error", "system_stopped"] },
+        },
+      });
+    } else {
+      const existingUserMessage = requestMessages.find(
+        (requestMessage) => requestMessage.sender === "user",
+      );
+      const alreadySucceeded = requestMessages.some(
+        (requestMessage) => requestMessage.sender === "parrot",
+      );
+      if (alreadySucceeded) {
+        return NextResponse.json(
+          { error: "This request already has a successful response" },
+          { status: 409 },
+        );
+      }
+      if (existingUserMessage && existingUserMessage.content !== message) {
+        return NextResponse.json(
+          { error: "Request ID is already associated with another message" },
+          { status: 409 },
+        );
+      }
+      if (!existingUserMessage) {
+        await prisma.chatMessage.create({
+          data: {
+            id: messageId?.trim() || undefined,
+            chatId,
+            requestId: resolvedRequestId,
+            sender: "user",
+            content: message,
+          },
+        });
+      }
     }
 
     const resolvedUserId = chatRecord.userId;
@@ -196,7 +329,7 @@ export async function POST(request: Request) {
       }),
       prisma.chatMessage.findMany({
         where: { chatId },
-        orderBy: { timestamp: "asc" },
+        orderBy: [{ timestamp: "asc" }, { id: "asc" }],
         select: { sender: true, content: true },
       }) as Promise<ChatMessageSummary[]>,
     ]);
@@ -211,6 +344,7 @@ export async function POST(request: Request) {
     // Capture variables for stream closure
     const capturedUserId = resolvedUserId;
     const capturedChatId = chatId;
+    const capturedRequestId = resolvedRequestId;
 
     const stream = new ReadableStream({
       async start(controller) {
@@ -221,6 +355,7 @@ export async function POST(request: Request) {
             type: "progress",
             title: "Processing",
             content: "Preparing your response...",
+            requestId: capturedRequestId,
           },
           controller
         );
@@ -242,6 +377,7 @@ export async function POST(request: Request) {
         const enqueueMessage = (sender: string, content: string) => {
           pendingMessages.push({
             chatId: capturedChatId,
+            requestId: capturedRequestId,
             sender,
             content,
             // Ensure stable chronology even when createMany writes rows in one batch.
@@ -342,7 +478,15 @@ export async function POST(request: Request) {
           }
           emittedToolSummaries.add(canonical);
 
-          sendProgress({ type: "tool_summary", toolName, content, raw }, controller);
+          sendProgress(
+            {
+              type: "tool_summary",
+              toolName,
+              content,
+              requestId: capturedRequestId,
+            },
+            controller,
+          );
           enqueueMessage("tool_summary", JSON.stringify({ toolName: normalizedToolName, content, raw }));
           // Keep naming context lean and human-readable, avoid large raw payloads.
           conversationMessages.push({
@@ -353,15 +497,11 @@ export async function POST(request: Request) {
 
         try {
 
-          // Only add and save user message if not auto-triggered. This is from `app/[chatId]/page.tsx`, when you load the page and the last message is from the user.
-          if (!isAutoTrigger) {
-            const userMessage = { sender: "user", content: message };
-            conversationMessages.push(userMessage);
-            enqueueMessage("user", message);
-          }
+          void isAutoTrigger;
 
           // Parrot's answer
           let parrotReply = "";
+          let generationStopped = false;
           try {
             // Build message history with system prompt (Prisma context already injected)
             const parrotHistory = buildParrotHistory(conversationMessages, newParrotSysPrompt);
@@ -376,6 +516,7 @@ export async function POST(request: Request) {
                   thread_id: capturedChatId,
                   userId: capturedUserId,
                 },
+                signal: request.signal,
               }
             );
 
@@ -388,7 +529,12 @@ export async function POST(request: Request) {
                   toolsWithCustomProgress.add(canonicalToolKey(customData.toolName));
                   // tool_progress event (ephemeral)
                   sendProgress(
-                    { type: "tool_progress", toolName: displayToolName(customData.toolName), message: customData.message },
+                    {
+                      type: "tool_progress",
+                      toolName: displayToolName(customData.toolName),
+                      message: customData.message,
+                      requestId: capturedRequestId,
+                    },
                     controller
                   );
                 } else if (customData?.toolName && customData.content) {
@@ -414,7 +560,14 @@ export async function POST(request: Request) {
                   for (const block of token.contentBlocks) {
                     if (typeof block.text === "string") {
                       parrotReply += block.text;
-                      sendProgress({ type: "parrot", content: block.text }, controller);
+                      sendProgress(
+                        {
+                          type: "parrot",
+                          content: block.text,
+                          requestId: capturedRequestId,
+                        },
+                        controller,
+                      );
                     }
                   }
                 }
@@ -435,6 +588,7 @@ export async function POST(request: Request) {
                         type: "progress",
                         title: "Drafting response",
                         content: "Turning insights into a clear answer...",
+                        requestId: capturedRequestId,
                       },
                       controller
                     );
@@ -445,6 +599,7 @@ export async function POST(request: Request) {
                         type: "progress",
                         title: "Finalizing response",
                         content: "Synthesizing research into your answer...",
+                        requestId: capturedRequestId,
                       },
                       controller
                     );
@@ -468,7 +623,12 @@ export async function POST(request: Request) {
                     // send a generic progress event so the user sees activity
                     if (!isSupplemental && !isCcel && !toolsWithCustomProgress.has(toolKey)) {
                       sendProgress(
-                        { type: "tool_progress", toolName: readableToolName, message: `Using ${readableToolName}...` },
+                        {
+                          type: "tool_progress",
+                          toolName: readableToolName,
+                          message: `Using ${readableToolName}...`,
+                          requestId: capturedRequestId,
+                        },
                         controller
                       );
                     }
@@ -525,7 +685,21 @@ export async function POST(request: Request) {
               });
             }
           } catch (error) {
-            sendError(error, "parrot_response", controller);
+            generationStopped =
+              request.signal.aborted ||
+              (error instanceof Error && error.name === "AbortError");
+            if (generationStopped) {
+              enqueueMessage("system_stopped", "Response stopped by the user.");
+            } else {
+              const failureMessage = "We couldn't finish this response.";
+              enqueueMessage("system_error", failureMessage);
+              sendError(
+                error,
+                "parrot_response",
+                controller,
+                capturedRequestId,
+              );
+            }
           }
 
           // Persist messages to database (without conversation naming - that's deferred)
@@ -563,7 +737,11 @@ export async function POST(request: Request) {
               select: { conversationName: true },
             });
 
-            if (currentChat && currentChat.conversationName === "New Conversation") {
+            if (
+              parrotReply.trim() &&
+              currentChat &&
+              currentChat.conversationName === "New Conversation"
+            ) {
               const allMessagesStr = conversationMessages.map((m) => `${m.sender}: ${m.content}`).join("\n");
               const conversationName = await generateConversationName(allMessagesStr);
               const finalName = conversationName || "New Conversation";
@@ -575,7 +753,12 @@ export async function POST(request: Request) {
 
               // Send name update event so client can update sidebar immediately
               sendProgress(
-                { type: "conversationNameUpdated", chatId: capturedChatId, name: finalName },
+                {
+                  type: "conversationNameUpdated",
+                  chatId: capturedChatId,
+                  name: finalName,
+                  requestId: capturedRequestId,
+                },
                 controller
               );
             }
@@ -585,14 +768,26 @@ export async function POST(request: Request) {
           }
 
           // Send "done" and close stream
-          sendProgress({ type: "done" }, controller);
-          controller.close();
+          if (!generationStopped && !request.signal.aborted) {
+            sendProgress(
+              {
+                type: "done",
+                requestId: capturedRequestId,
+              },
+              controller,
+            );
+          }
+          try {
+            controller.close();
+          } catch {
+            // The client may already have closed the stream after Stop.
+          }
 
           // === Background tasks (fire-and-forget, don't block response) ===
           // Memory extraction runs after stream closes since client doesn't need this data
 
           // 2. Extract and update user memories asynchronously
-          if (capturedUserId) {
+          if (capturedUserId && parrotReply.trim()) {
             updateUserMemoriesFromConversation(
               capturedUserId,
               conversationMessages.map((m) => ({
@@ -606,14 +801,31 @@ export async function POST(request: Request) {
             console.warn("⚠️ Memory extraction skipped: userId is undefined");
           }
         } catch (error) {
-          sendError(error, "general", controller);
-          controller.close();
+          if (!request.signal.aborted) {
+            enqueueMessage("system_error", "We couldn't finish this response.");
+            if (pendingMessages.length > 0) {
+              await prisma.chatMessage.createMany({ data: pendingMessages }).catch(
+                (persistError) => {
+                  console.error("Failed to persist request failure:", persistError);
+                },
+              );
+            }
+            sendError(error, "general", controller, capturedRequestId);
+          }
+          try {
+            controller.close();
+          } catch {
+            // The client may already have closed the stream after Stop.
+          }
         }
       },
     });
 
     return new Response(stream, {
-      headers: { "Content-Type": "text/plain; charset=utf-8" },
+      headers: {
+        "Content-Type": "application/x-ndjson; charset=utf-8",
+        "Cache-Control": "no-store",
+      },
     });
   }
 
@@ -623,7 +835,7 @@ export async function POST(request: Request) {
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const chatId = searchParams.get("chatId");
-  const actor = await resolveChatActor({ externalUserId: searchParams.get("userId") });
+  const actor = await resolveChatActor();
   const requesterUserId = getChatActorId(actor);
 
   if (!chatId) {
@@ -652,7 +864,6 @@ export async function GET(request: Request) {
           ...msg,
           toolName: parsed.toolName,
           content: parsed.content,
-          raw: parsed.raw,
         };
       } catch (e) {
         console.error("Failed to parse tool_summary message:", e);

--- a/app/api/user-chats/route.ts
+++ b/app/api/user-chats/route.ts
@@ -3,6 +3,12 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { getChatActorId, resolveChatActor } from '@/lib/guest';
+import { z } from 'zod';
+
+const renameSchema = z.object({
+  chatId: z.string().trim().min(1),
+  conversationName: z.string().trim().min(1).max(120),
+});
 
 export async function GET(request: Request) {
   void request;
@@ -11,13 +17,42 @@ export async function GET(request: Request) {
 
   const chats = await prisma.chatHistory.findMany({
     where: { userId: authenticatedUserId },
-    select: { id: true, conversationName: true },
+    select: { id: true, conversationName: true, modifiedAt: true },
     orderBy: { modifiedAt: 'desc' },
   });
 
   // console.log(chats);
 
   return NextResponse.json({ chats });
+}
+
+export async function PATCH(request: Request) {
+  const parsed = renameSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid rename request' }, { status: 400 });
+  }
+
+  const actor = await resolveChatActor();
+  const effectiveUserId = getChatActorId(actor);
+  const existing = await prisma.chatHistory.findUnique({
+    where: { id: parsed.data.chatId },
+    select: { userId: true },
+  });
+
+  if (!existing) {
+    return NextResponse.json({ error: 'Chat not found' }, { status: 404 });
+  }
+  if (existing.userId !== effectiveUserId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const chat = await prisma.chatHistory.update({
+    where: { id: parsed.data.chatId },
+    data: { conversationName: parsed.data.conversationName },
+    select: { id: true, conversationName: true, modifiedAt: true },
+  });
+
+  return NextResponse.json({ chat });
 }
 
 export async function DELETE(request: Request) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -96,15 +96,15 @@
     /* Brand: Deep Blue #004D70 - Parrot message bubbles */
     --parrot-message: 199 100% 22%;
     --parrot-message-foreground: 0 0% 100%;
-    /* Sidebar - Matches background for cohesion */
-    --sidebar-background: 42 56% 91%;
+    /* Sidebar - A slightly deeper cream separates navigation from content */
+    --sidebar-background: 42 35% 87%;
     --sidebar-foreground: 0 0% 20%;
     --sidebar-primary: 0 0% 20%;
     --sidebar-primary-foreground: 0 0% 98%;
     /* Brand: Mint Green #5ABFB1 - Sidebar active states */
     --sidebar-accent: 172 43% 55%;
     --sidebar-accent-foreground: 0 0% 20%;
-    --sidebar-border: 0 0% 88%;
+    --sidebar-border: 42 20% 74%;
     --sidebar-ring: 199 100% 22%;
   }
 

--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState, useCallback } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/use-auth";
+import { useAutoGrowingTextarea } from "@/hooks/use-auto-growing-textarea";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { ProtectedView } from "@/components/ProtectedView";
 import { Button } from "@/components/ui/button";
@@ -14,7 +15,14 @@ import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Loader2, Plus, Search, MessageSquare, BookOpen, Calendar, ChevronRight } from "lucide-react";
 import { ReflectionCard } from "./components/ReflectionCard";
 import { SuggestedRequestsPanel } from "./components/SuggestedRequestsPanel";
@@ -108,6 +116,15 @@ export default function JournalPage() {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [isComposerOpen, setIsComposerOpen] = useState(false);
   const [newEntryText, setNewEntryText] = useState("");
+  const {
+    textareaRef: journalEntryTextareaRef,
+    handleInput: handleJournalEntryInput,
+  } = useAutoGrowingTextarea(newEntryText, {
+    minHeight: 200,
+    maxHeight: 560,
+    maxViewportRatio: 0.42,
+    enabled: isComposerOpen,
+  });
   const [activeEntry, setActiveEntry] = useState<JournalEntry | null>(null);
   const [mobileDetailOpen, setMobileDetailOpen] = useState(false);
 
@@ -698,74 +715,93 @@ export default function JournalPage() {
         )}
 
         {/* Composer Modal/Dialog */}
-        {isComposerOpen && (
-          <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-            <Card className="w-full max-w-2xl max-h-[80vh] overflow-auto">
-              <CardHeader>
-                <CardTitle className="font-serif">New Journal Entry</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <p className="text-sm text-muted-foreground">
-                  What is on your heart today? Reflect on circumstances, emotions, struggles, or thanksgivings.
-                  Consider: What happened? How did you respond? What might God be teaching you?
-                </p>
-                <div>
-                  <Textarea
-                    placeholder="Write your journal entry..."
-                    value={newEntryText}
-                    onChange={(e) => setNewEntryText(e.target.value)}
-                    className="min-h-[200px]"
-                    disabled={isSubmitting}
-                  />
-                  <p className="text-xs text-muted-foreground mt-2">
-                    Tip: Reflect on what happened, how you responded, and what God might be teaching you
-                  </p>
-                </div>
-                {newEntryText.length === 0 && (
-                  <details className="text-sm">
-                    <summary className="cursor-pointer text-muted-foreground hover:text-foreground transition-colors">
-                      Need help getting started?
-                    </summary>
-                    <ul className="mt-2 space-y-1 text-muted-foreground ml-4 list-disc">
-                      <li>What happened today that stood out?</li>
-                      <li>How did you feel or respond?</li>
-                      <li>Where did you see God&apos;s hand?</li>
-                      <li>What are you struggling with?</li>
-                    </ul>
-                  </details>
+        <Dialog
+          open={isComposerOpen}
+          onOpenChange={(open) => {
+            if (!open && isSubmitting) return;
+            setIsComposerOpen(open);
+            if (!open) setNewEntryText("");
+          }}
+        >
+          <DialogContent className="flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-2xl flex-col gap-0 overflow-hidden rounded-2xl p-0 sm:max-h-[90dvh]">
+            <DialogHeader className="shrink-0 space-y-4 px-5 pb-0 pt-5 pr-12 text-left sm:px-6 sm:pt-6 sm:pr-12">
+              <DialogTitle className="font-serif">
+                New Journal Entry
+              </DialogTitle>
+              <DialogDescription className="text-sm leading-relaxed">
+                What is on your heart today? Reflect on circumstances,
+                emotions, struggles, or thanksgivings. Consider: What happened?
+                How did you respond? What might God be teaching you?
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 py-4 sm:px-6">
+              <Textarea
+                ref={journalEntryTextareaRef}
+                placeholder="Write your journal entry..."
+                value={newEntryText}
+                onInput={handleJournalEntryInput}
+                onChange={(e) => setNewEntryText(e.target.value)}
+                className="min-h-[200px] max-h-[42dvh] resize-none overflow-y-hidden"
+                disabled={isSubmitting}
+              />
+              <p className="mt-2 text-xs text-muted-foreground">
+                Tip: Reflect on what happened, how you responded, and what God
+                might be teaching you
+              </p>
+              {newEntryText.length === 0 && (
+                <details className="mt-4 text-sm">
+                  <summary className="cursor-pointer text-muted-foreground transition-colors hover:text-foreground">
+                    Need help getting started?
+                  </summary>
+                  <ul className="ml-4 mt-2 list-disc space-y-1 text-muted-foreground">
+                    <li>What happened today that stood out?</li>
+                    <li>How did you feel or respond?</li>
+                    <li>Where did you see God&apos;s hand?</li>
+                    <li>What are you struggling with?</li>
+                  </ul>
+                </details>
+              )}
+            </div>
+
+            <DialogFooter className="shrink-0 flex-row justify-end gap-2 border-t bg-background px-5 py-4 sm:px-6 sm:space-x-0">
+              <Button
+                variant="outline"
+                className="flex-1 sm:flex-none"
+                onClick={() => {
+                  setIsComposerOpen(false);
+                  setNewEntryText("");
+                }}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button
+                className="flex-1 sm:flex-none"
+                onClick={handleSubmitEntry}
+                disabled={!newEntryText.trim() || isSubmitting}
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2
+                      className="mr-2 h-4 w-4 animate-spin"
+                      aria-hidden="true"
+                    />
+                    Saving...
+                  </>
+                ) : (
+                  <>
+                    Save Entry
+                    <ChevronRight
+                      className="ml-1 h-4 w-4"
+                      aria-hidden="true"
+                    />
+                  </>
                 )}
-                <div className="flex justify-end gap-2">
-                  <Button
-                    variant="outline"
-                    onClick={() => {
-                      setIsComposerOpen(false);
-                      setNewEntryText("");
-                    }}
-                    disabled={isSubmitting}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    onClick={handleSubmitEntry}
-                    disabled={!newEntryText.trim() || isSubmitting}
-                  >
-                    {isSubmitting ? (
-                      <>
-                        <Loader2 className="h-4 w-4 animate-spin mr-2" />
-                        Saving...
-                      </>
-                    ) : (
-                      <>
-                        Save Entry
-                        <ChevronRight className="h-4 w-4 ml-1" />
-                      </>
-                    )}
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        )}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </main>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,153 +1,113 @@
-// app/page.tsx
-
 "use client";
 
 import { useState } from "react";
 import Image from "next/image";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
-import { Card, CardHeader, CardTitle, CardContent, CardDescription } from "@/components/ui/card";
 import { useRouter } from "next/navigation";
-import { AppSidebar } from "@/components/chat-sidebar";
-import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+
+import {
+  ChatComposer,
+  LANDING_CHAT_DISCLAIMER,
+} from "@/components/chat/chat-composer";
+import { ChatShell } from "@/components/chat/chat-shell";
+import { ChatShortcuts } from "@/components/chat/chat-shortcuts";
+import { SuggestedQuestions } from "@/components/chat/suggested-questions";
 import { useAuth } from "@/hooks/use-auth";
 import { useChatList } from "@/hooks/use-chat-list";
-import { BookOpen, Church, Sprout } from "lucide-react";
 
 export default function MainChatPage() {
   const [initialQuestion, setInitialQuestion] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const router = useRouter();
   const { user } = useAuth();
-  const { chats, createChat, upsertChat, removeChat } = useChatList(user?.$id ?? "guest");
+  const {
+    chats,
+    createChat,
+    upsertChat,
+    renameChat,
+    deleteChat,
+  } = useChatList(user?.$id ?? "guest");
 
-  const handleStartNewChat = (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleStartNewChat = () => {
     const question = initialQuestion.trim();
-    if (!question) return;
+    if (!question || createChat.isPending) return;
 
-    const newChatId = crypto.randomUUID();
-
+    const clientChatId = crypto.randomUUID();
+    const requestId = crypto.randomUUID();
     setErrorMessage("");
 
     createChat.mutate(
-      { initialQuestion: question, clientChatId: newChatId },
+      { initialQuestion: question, clientChatId, requestId },
       {
-        onSuccess: ({ chatId }) => {
-          upsertChat({ id: chatId, conversationName: "New Conversation" });
+        onSuccess: ({ chatId, messageId }) => {
+          upsertChat({
+            id: chatId,
+            conversationName: "New Conversation",
+          });
+          router.push(`/${chatId}?autoSendMessageId=${encodeURIComponent(messageId)}`);
         },
         onError: (error) => {
           console.error("Error starting new chat:", error);
-          setErrorMessage("An error occurred while starting a new chat.");
+          setErrorMessage(
+            "We could not start the conversation. Please try again.",
+          );
         },
-      }
+      },
     );
-
-    router.push(`/${newChatId}?initialQuestion=${encodeURIComponent(question)}`);
   };
 
   return (
-    <SidebarProvider style={{ minHeight: "calc(100vh - var(--app-header-height))" }}>
-      <AppSidebar
-        chats={chats}
-        onDeleted={(id) => {
-          // Optimistically remove from cache
-          removeChat(id);
-        }}
-      />
-      <SidebarInset className="flex h-[calc(100vh-var(--app-header-height))] flex-col overflow-hidden relative">
-        <header className="absolute top-0 left-0 z-20 flex h-16 items-center px-4">
-          <SidebarTrigger className="-ml-1" />
-        </header>
-        <div className="relative flex flex-1 flex-col overflow-y-auto px-4">
-          <div
-            className="flex min-h-0 flex-1 items-start justify-center pb-10"
-            style={{ paddingTop: "clamp(0.5rem, calc((100vh - var(--app-header-height)) * 0.12), 10rem)" }}
-          >
-            <Card className="w-full max-w-3xl">
-              <CardHeader>
-                <div className="flex items-center space-x-4 landscape:hidden md:landscape:flex">
-                  <Image
-                    src="/Logo.png"
-                    alt="Calvinist Parrot"
-                    width={100}
-                    height={100}
-                    priority
-                    unoptimized={true}
-                    className="landscape:h-16 landscape:w-16"
-                  />
-                  <CardTitle className="w-full justify-center text-3xl font-bold landscape:text-2xl">
-                    Calvinist Parrot
-                  </CardTitle>
-                </div>
-                <CardDescription>What theological question do you have?</CardDescription>
-              </CardHeader>
-              <CardContent>
-                {errorMessage && <p className="mb-4 text-destructive">{errorMessage}</p>}
-                <form onSubmit={handleStartNewChat} className="space-y-4">
-                  <Textarea
-                    placeholder="Enter your question here..."
-                    value={initialQuestion}
-                    onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setInitialQuestion(e.target.value)}
-                  />
-                  <Button type="submit" className="w-full">
-                    Start Chat
-                  </Button>
-                </form>
-              </CardContent>
-            </Card>
+    <ChatShell
+      chats={chats}
+      title="New chat"
+      onDelete={(chatId) =>
+        deleteChat.mutateAsync(chatId).then(() => undefined)
+      }
+      onRename={(chatId, conversationName) =>
+        renameChat.mutateAsync({ chatId, conversationName }).then(() => undefined)
+      }
+      contentClassName="overflow-y-auto"
+    >
+      <div className="mx-auto flex min-h-full w-full max-w-4xl flex-col px-4 pb-5 pt-5 sm:px-6 sm:pb-6 sm:pt-8 lg:justify-center lg:py-12">
+        <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col landscape:flex-none lg:flex-none">
+          <header className="mb-6 text-center">
+            <Image
+              src="/Logo.png"
+              alt=""
+              width={88}
+              height={88}
+              priority
+              className="mx-auto mb-3 hidden h-20 w-20 min-[390px]:block sm:h-24 sm:w-24"
+            />
+            <h2 className="font-serif text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              Calvinist Parrot
+            </h2>
+            <p className="mt-2 text-muted-foreground">
+              What theological question do you have?
+            </p>
+          </header>
+
+          <ChatComposer
+            value={initialQuestion}
+            onChange={setInitialQuestion}
+            onSubmit={handleStartNewChat}
+            isSubmitting={createChat.isPending}
+            placeholder="Enter your question here..."
+            submitLabel="Start Chat"
+            layout="stacked"
+            size="hero"
+            disclaimer={LANDING_CHAT_DISCLAIMER}
+            autoFocus
+            error={errorMessage}
+          />
+
+          <div className="mt-5">
+            <SuggestedQuestions onSelect={setInitialQuestion} />
           </div>
-
-          {/* Feature shortcuts */}
-          <div className="flex flex-wrap justify-center gap-2 pb-6 pt-4 lg:hidden landscape:hidden">
-            <Link
-              href="/devotional"
-              prefetch={false}
-              className="badge--neutral inline-flex items-center gap-1.5 px-3 py-2 text-sm transition-all hover:opacity-80"
-            >
-              <span className="material-symbols-outlined" style={{ fontSize: '1rem', lineHeight: 1 }}>candle</span>
-              <span>Devotional</span>
-            </Link>
-
-            <Link
-              href="/journal"
-              prefetch={false}
-              className="badge--neutral inline-flex items-center gap-1.5 px-3 py-2 text-sm transition-all hover:opacity-80"
-            >
-              <BookOpen className="h-4 w-4" />
-              <span>Journal</span>
-            </Link>
-
-            <Link
-              href="/prayer-tracker"
-              prefetch={false}
-              className="badge--neutral inline-flex items-center gap-1.5 px-3 py-2 text-sm transition-all hover:opacity-80"
-            >
-              <span className="material-symbols-outlined" style={{ fontSize: '1rem', lineHeight: 1 }}>folded_hands</span>
-              <span>Prayer Tracker</span>
-            </Link>
-
-            <Link
-              href="/kids-discipleship"
-              prefetch={false}
-              className="badge--neutral inline-flex items-center gap-1.5 px-3 py-2 text-sm transition-all hover:opacity-80"
-            >
-              <Sprout className="h-4 w-4" />
-              <span>Heritage</span>
-            </Link>
-
-            <Link
-              href="/church-finder"
-              prefetch={false}
-              className="badge--neutral inline-flex items-center gap-1.5 px-3 py-2 text-sm transition-all hover:opacity-80"
-            >
-              <Church className="h-4 w-4" />
-              <span>Church Finder</span>
-            </Link>
+          <div className="mt-auto pt-6 lg:hidden landscape:hidden">
+            <ChatShortcuts />
           </div>
         </div>
-      </SidebarInset>
-    </SidebarProvider>
+      </div>
+    </ChatShell>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -57,7 +57,7 @@ export function Header() {
 
   return (
     <header
-      className={`app-header sticky top-0 z-50 w-full px-4 transition-all duration-700 ease-in-out ${
+      className={`app-header sticky top-0 z-50 w-full px-2 transition-all duration-700 ease-in-out sm:px-4 ${
         isScrolled ? "liquid-glass-header" : ""
       }`}
       style={{
@@ -72,8 +72,8 @@ export function Header() {
         }}
       >
         {/* Left side: Logo and Navigation */}
-        <div className="flex items-center space-x-2">
-          <Link href="/" prefetch={false} className="flex items-center space-x-2 hover:opacity-70 transition-opacity">
+        <div className="flex min-w-0 items-center gap-1 sm:gap-2">
+          <Link href="/" prefetch={false} className="flex min-w-0 items-center gap-1 hover:opacity-70 transition-opacity sm:gap-2">
             <Image
               src="/Logo.png"
               alt="Calvinist Parrot"
@@ -86,15 +86,11 @@ export function Header() {
               height={50}
             />
             <span
-              className="app-logo overflow-hidden transition-opacity duration-700 ease-in-out"
+              className="app-logo hidden min-w-0 max-w-[200px] overflow-hidden transition-opacity duration-700 ease-in-out sm:block"
               style={
                 {
                   // Keep width stable and only fade to avoid layout glitches
-                  maxWidth: "200px",
                   opacity: isScrolled ? 0 : 1,
-                  display: "-webkit-box",
-                  WebkitLineClamp: 2,
-                  WebkitBoxOrient: "vertical",
                 } as React.CSSProperties
               }
             >
@@ -104,7 +100,7 @@ export function Header() {
 
           {/* Fade-out separator when scrolled */}
           <span
-            className="transition-opacity duration-700 ease-in-out"
+            className="hidden transition-opacity duration-700 ease-in-out min-[360px]:inline-block"
             style={{ opacity: isScrolled ? 0 : 1, pointerEvents: isScrolled ? "none" : "auto" }}
             aria-hidden={isScrolled}
           >
@@ -227,13 +223,13 @@ export function Header() {
         <div className="flex-1" />
 
         {/* Right side: Theme toggle and user session actions */}
-        <div className="flex items-center space-x-2">
+        <div className="flex shrink-0 items-center gap-1 sm:gap-2">
           {/* Hide ThemeToggle when scrolled for a cleaner compact header */}
           {!isScrolled && <ThemeToggle />}
           {loading ? null : user ? (
             // If logged in, show the user's name linking to profile
             <Link href="/profile" prefetch={false}>
-              <Button variant="outline" className="hover:bg-muted/50" size={isScrolled ? "xsm" : "default"}>
+              <Button variant="outline" className="hover:bg-muted/50 max-sm:h-8 max-sm:px-2 max-sm:text-xs" size={isScrolled ? "xsm" : "default"}>
                 {user.name}
               </Button>
             </Link>
@@ -241,13 +237,13 @@ export function Header() {
             <>
               {/* If not logged in, show Login and Register */}
               <Link href="/login" prefetch={false}>
-                <Button variant="outline" className="hover:bg-muted/50" size={isScrolled ? "sm" : "default"}>
+                <Button variant="outline" className="hover:bg-muted/50 max-sm:h-8 max-sm:px-2 max-sm:text-xs" size={isScrolled ? "sm" : "default"}>
                   Login
                 </Button>
               </Link>
               <Link href="/register" prefetch={false}>
                 <Button
-                  className="bg-accent text-accent-foreground hover:bg-accent/90"
+                  className="bg-accent text-accent-foreground hover:bg-accent/90 max-sm:h-8 max-sm:px-2 max-sm:text-xs"
                   size={isScrolled ? "sm" : "default"}
                 >
                   Register

--- a/components/chat-sidebar.tsx
+++ b/components/chat-sidebar.tsx
@@ -1,114 +1,285 @@
-// components/chat-sidebar.tsx
+"use client";
 
 import * as React from "react";
 import type { CSSProperties } from "react";
+import Link from "next/link";
+import { MoreHorizontal, Pencil, Plus, Search, Trash2 } from "lucide-react";
+
+import type { ChatSummary } from "@/hooks/use-chat-list";
+import { chatTitleMatches, groupChatsByDate } from "@/lib/chat-list";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import {
   Sidebar,
   SidebarContent,
   SidebarGroup,
   SidebarGroupContent,
-  // SidebarGroupLabel,
+  SidebarGroupLabel,
   SidebarHeader,
+  SidebarInput,
   SidebarMenu,
+  SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarSeparator,
 } from "@/components/ui/sidebar";
-import Link from "next/link";
-import { Trash2 } from "lucide-react";
-import { useCallback } from "react";
-
-type ChatItem = {
-  id: string;
-  conversationName: string;
-};
 
 interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
-  chats: ChatItem[];
+  chats: ChatSummary[];
   currentChatId?: string;
+  onDelete: (chatId: string) => Promise<void>;
+  onRename: (chatId: string, conversationName: string) => Promise<void>;
   onDeleted?: (chatId: string) => void;
 }
 
-export function AppSidebar({ chats, currentChatId, onDeleted, className, style, ...props }: AppSidebarProps) {
+type PendingAction =
+  | { type: "rename"; chat: ChatSummary }
+  | { type: "delete"; chat: ChatSummary }
+  | null;
+
+export function AppSidebar({
+  chats,
+  currentChatId,
+  onDelete,
+  onRename,
+  onDeleted,
+  className,
+  style,
+  ...props
+}: AppSidebarProps) {
+  const [query, setQuery] = React.useState("");
+  const [pendingAction, setPendingAction] = React.useState<PendingAction>(null);
+  const [renameValue, setRenameValue] = React.useState("");
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [announcement, setAnnouncement] = React.useState("");
+  const locale =
+    typeof navigator === "undefined" ? "en" : navigator.language || "en";
+
+  const visibleChats = React.useMemo(
+    () =>
+      chats.filter((chat) =>
+        chatTitleMatches(chat.conversationName || "Unnamed Conversation", query, locale),
+      ),
+    [chats, locale, query],
+  );
+  const groups = React.useMemo(() => groupChatsByDate(visibleChats), [visibleChats]);
+  const dateFormatter = React.useMemo(
+    () => new Intl.DateTimeFormat(locale, { dateStyle: "medium" }),
+    [locale],
+  );
+
   const mergedStyle = {
     ...style,
     top: "var(--app-header-height)",
     height: "calc(100vh - var(--app-header-height))",
+    borderColor: "hsl(var(--sidebar-border))",
+    boxShadow: "2px 0 8px hsl(var(--foreground) / 0.04)",
   } as CSSProperties;
 
-  const handleDelete = useCallback(
-    async (chatId: string) => {
-      try {
-        const params = new URLSearchParams({ chatId });
-        // Actor ownership is resolved on the server from the Appwrite session or guest cookie.
-        const res = await fetch(`/api/user-chats?${params.toString()}`, { method: "DELETE" });
-        if (!res.ok) throw new Error("Failed to delete chat");
-        onDeleted?.(chatId);
-      } catch (e) {
-        console.error("Delete chat failed", e);
+  const openRename = (chat: ChatSummary) => {
+    setRenameValue(chat.conversationName);
+    setPendingAction({ type: "rename", chat });
+  };
+
+  const finishAction = async () => {
+    if (!pendingAction) return;
+    setIsSaving(true);
+    try {
+      if (pendingAction.type === "rename") {
+        const name = renameValue.trim();
+        if (!name) return;
+        await onRename(pendingAction.chat.id, name);
+        setAnnouncement(`Renamed conversation to ${name}.`);
+      } else {
+        await onDelete(pendingAction.chat.id);
+        onDeleted?.(pendingAction.chat.id);
+        setAnnouncement("Conversation deleted.");
       }
-    },
-    [onDeleted]
-  );
+      setPendingAction(null);
+    } catch (error) {
+      console.error("Conversation action failed:", error);
+      setAnnouncement(
+        pendingAction.type === "rename"
+          ? "The conversation could not be renamed."
+          : "The conversation could not be deleted.",
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
 
   return (
-    <Sidebar {...props} className={`${className} transition-[top,height] duration-700 ease-in-out`} style={mergedStyle}>
-      <SidebarContent>
-        <SidebarHeader className="pt-6 pb-2 font-serif font-semibold text-accent text-lg">
-          Your Conversations
+    <>
+      <Sidebar
+        {...props}
+        className={`${className ?? ""} transition-[top,height] duration-200 motion-reduce:transition-none`}
+        style={mergedStyle}
+      >
+        <SidebarHeader className="gap-3 p-3">
+          <Button asChild className="w-full justify-start">
+            <Link href="/" prefetch={false}>
+              <Plus className="h-4 w-4" />
+              New chat
+            </Link>
+          </Button>
+          <div className="relative">
+            <Search
+              aria-hidden="true"
+              className="pointer-events-none absolute start-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            />
+            <SidebarInput
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search conversations"
+              aria-label="Search conversations"
+              className="h-10 bg-input-bg ps-8"
+            />
+          </div>
         </SidebarHeader>
-        <SidebarSeparator />
-        <SidebarGroup className="pt-2">
-          <SidebarGroupContent>
-            <SidebarMenu className="gap-0">
-              {chats.map((c) => (
-                <React.Fragment key={c.id}>
-                  <SidebarMenuItem className="px-2 py-0.5 border-t border-sidebar-border first:border-t-0">
-                    <div className="group flex items-center justify-between gap-2">
+        <SidebarContent>
+          {groups.map((group) => (
+            <SidebarGroup key={group.key} className="pt-1">
+              <SidebarGroupLabel className="font-semibold">
+                {group.label}
+              </SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  {group.chats.map((chat) => (
+                    <SidebarMenuItem key={chat.id}>
                       <SidebarMenuButton
                         asChild
-                        isActive={c.id === currentChatId}
+                        isActive={chat.id === currentChatId}
                         size="lg"
-                        className="sidebar-button flex-1 text-left h-auto min-h-8 py-1.5"
+                        className="sidebar-button h-auto min-h-12 pe-11"
                       >
-                        <Link href={`/${c.id}`} prefetch={false} title={c.conversationName || "Unnamed Conversation"}>
-                          <span
-                            className="block text-sm leading-tight"
-                            style={{
-                              display: "-webkit-box",
-                              WebkitBoxOrient: "vertical",
-                              overflow: "hidden",
-                              WebkitLineClamp: 2,
-                              wordBreak: "break-word",
-                              whiteSpace: "normal",
-                            }}
-                          >
-                            {c.conversationName || "Unnamed Conversation"}
+                        <Link
+                          href={`/${chat.id}`}
+                          prefetch={false}
+                          title={`${chat.conversationName || "Unnamed Conversation"} — ${dateFormatter.format(new Date(chat.modifiedAt))}`}
+                        >
+                          <span className="line-clamp-2 whitespace-normal break-words text-start leading-snug">
+                            {chat.conversationName || "Unnamed Conversation"}
                           </span>
                         </Link>
                       </SidebarMenuButton>
-                      <button
-                        type="button"
-                        aria-label="Delete chat"
-                        title="Delete chat"
-                        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-destructive transition-opacity duration-150 md:opacity-0 md:group-hover:opacity-100 md:focus-within:opacity-100 md:pointer-events-none md:group-hover:pointer-events-auto"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          handleDelete(c.id);
-                        }}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    </div>
-                  </SidebarMenuItem>
-                  {/* Separator replaced by item borders for tighter spacing */}
-                </React.Fragment>
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      </SidebarContent>
-    </Sidebar>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <SidebarMenuAction
+                            aria-label={`Actions for ${chat.conversationName || "Unnamed Conversation"}`}
+                            className="top-2 h-8 w-8"
+                          >
+                            <MoreHorizontal className="h-4 w-4" />
+                          </SidebarMenuAction>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="max-w-64">
+                          <DropdownMenuItem
+                            className="whitespace-normal"
+                            onSelect={() => openRename(chat)}
+                          >
+                            <Pencil className="h-4 w-4" />
+                            Rename
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            className="whitespace-normal text-destructive focus:text-destructive"
+                            onSelect={() => setPendingAction({ type: "delete", chat })}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </SidebarMenuItem>
+                  ))}
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          ))}
+          {visibleChats.length === 0 ? (
+            <p className="px-4 py-6 text-sm text-muted-foreground">
+              {query ? "No conversations match your search." : "Your conversations will appear here."}
+            </p>
+          ) : null}
+        </SidebarContent>
+      </Sidebar>
+
+      <Dialog
+        open={Boolean(pendingAction)}
+        onOpenChange={(open) => {
+          if (!open && !isSaving) setPendingAction(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {pendingAction?.type === "rename"
+                ? "Rename conversation"
+                : "Delete conversation?"}
+            </DialogTitle>
+            <DialogDescription>
+              {pendingAction?.type === "rename"
+                ? "Choose a clear name you will recognize later."
+                : "This permanently removes the conversation and its messages."}
+            </DialogDescription>
+          </DialogHeader>
+          {pendingAction?.type === "rename" ? (
+            <Input
+              autoFocus
+              value={renameValue}
+              onChange={(event) => setRenameValue(event.target.value)}
+              maxLength={120}
+              aria-label="Conversation name"
+              className="bg-input-bg"
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.nativeEvent.isComposing) {
+                  event.preventDefault();
+                  void finishAction();
+                }
+              }}
+            />
+          ) : null}
+          <DialogFooter className="gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setPendingAction(null)}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant={pendingAction?.type === "delete" ? "destructive" : "default"}
+              onClick={() => void finishAction()}
+              disabled={
+                isSaving ||
+                (pendingAction?.type === "rename" && !renameValue.trim())
+              }
+            >
+              {isSaving
+                ? "Saving…"
+                : pendingAction?.type === "rename"
+                  ? "Rename"
+                  : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <p className="sr-only" aria-live="polite">
+        {announcement}
+      </p>
+    </>
   );
 }

--- a/components/chat/chat-composer.tsx
+++ b/components/chat/chat-composer.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useId, useRef } from "react";
+import { Loader2, Send, Square } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useAutoGrowingTextarea } from "@/hooks/use-auto-growing-textarea";
+import { cn } from "@/lib/utils";
+
+export const LANDING_CHAT_DISCLAIMER =
+  "The Parrot is not a substitute for your own study, prayer, or pastoral counsel.";
+
+export const CONVERSATION_CHAT_DISCLAIMER =
+  "The Parrot can make mistakes. Check important claims against Scripture and your elders/pastors.";
+
+type ChatComposerProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  onStop?: () => void;
+  isStreaming?: boolean;
+  isSubmitting?: boolean;
+  progress?: { title: string; content: string } | null;
+  placeholder?: string;
+  submitLabel?: string;
+  layout?: "inline" | "stacked";
+  size?: "default" | "hero";
+  disclaimer?: string;
+  autoFocus?: boolean;
+  error?: string;
+};
+
+export function ChatComposer({
+  value,
+  onChange,
+  onSubmit,
+  onStop,
+  isStreaming = false,
+  isSubmitting = false,
+  progress,
+  placeholder = "Type your message...",
+  submitLabel = "Send",
+  layout = "inline",
+  size = "default",
+  disclaimer = CONVERSATION_CHAT_DISCLAIMER,
+  autoFocus = false,
+  error,
+}: ChatComposerProps) {
+  const isComposingRef = useRef(false);
+  const disclaimerId = useId();
+  const { textareaRef, handleInput } = useAutoGrowingTextarea(value, {
+    minHeight: size === "hero" ? 144 : 72,
+    maxHeight: size === "hero" ? 560 : 200,
+    maxViewportRatio: size === "hero" ? 0.6 : 0.4,
+  });
+
+  const submit = () => {
+    if (isStreaming || isSubmitting || isComposingRef.current || !value.trim()) {
+      return;
+    }
+    onSubmit();
+  };
+
+  return (
+    <section
+      aria-label="Message composer"
+      className="border border-input bg-input-bg p-3 shadow-[0_8px_30px_hsl(var(--foreground)/0.08)] sm:p-4"
+      style={{ borderRadius: "var(--radius)" }}
+    >
+      {progress ? (
+        <div
+          className="mb-3 flex items-start gap-2 rounded-md bg-muted/65 px-3 py-2 text-sm"
+          aria-live="polite"
+        >
+          <Loader2
+            className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-primary motion-reduce:animate-none"
+            aria-hidden="true"
+          />
+          <div>
+            <p className="font-medium text-foreground">{progress.title}</p>
+            <p className="text-muted-foreground">{progress.content}</p>
+          </div>
+        </div>
+      ) : null}
+      <form
+        className={cn(
+          "flex gap-3",
+          layout === "stacked" ? "flex-col" : "items-end",
+        )}
+        onSubmit={(event) => {
+          event.preventDefault();
+          submit();
+        }}
+      >
+        <Textarea
+          ref={textareaRef}
+          autoFocus={autoFocus}
+          value={value}
+          onInput={handleInput}
+          onChange={(event) => onChange(event.target.value)}
+          onCompositionStart={() => {
+            isComposingRef.current = true;
+          }}
+          onCompositionEnd={() => {
+            isComposingRef.current = false;
+          }}
+          onKeyDown={(event) => {
+            if (
+              event.key === "Enter" &&
+              !event.shiftKey &&
+              !event.nativeEvent.isComposing &&
+              !isComposingRef.current
+            ) {
+              event.preventDefault();
+              submit();
+            }
+          }}
+          placeholder={placeholder}
+          aria-describedby={disclaimerId}
+          dir="auto"
+          disabled={isSubmitting || isStreaming}
+          className={cn(
+            "resize-none border-input bg-input-bg text-base leading-relaxed shadow-none",
+            layout === "inline" ? "flex-1" : "w-full shrink-0",
+            size === "hero"
+              ? "min-h-36 max-h-[60vh] px-4 py-4 sm:text-base"
+              : "min-h-[72px] max-h-[200px] sm:text-sm",
+          )}
+        />
+        {isStreaming ? (
+          <Button
+            type="button"
+            variant="outline"
+            className={cn(
+              "min-h-11 shrink-0 whitespace-normal",
+              layout === "stacked" && "w-full",
+            )}
+            onClick={onStop}
+          >
+            <Square className="h-4 w-4 fill-current" aria-hidden="true" />
+            Stop
+          </Button>
+        ) : (
+          <Button
+            type="submit"
+            className={cn(
+              "min-h-11 shrink-0 whitespace-normal",
+              layout === "stacked" && "w-full",
+            )}
+            disabled={isSubmitting || !value.trim()}
+          >
+            {isSubmitting ? (
+              <Loader2
+                className="h-4 w-4 animate-spin motion-reduce:animate-none"
+                aria-hidden="true"
+              />
+            ) : (
+              <Send className="h-4 w-4" aria-hidden="true" />
+            )}
+            {submitLabel}
+          </Button>
+        )}
+      </form>
+      {error ? (
+        <p className="mt-2 text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <p
+        id={disclaimerId}
+        className={cn(
+          "mt-3 pb-[max(0rem,env(safe-area-inset-bottom))] leading-relaxed text-muted-foreground",
+          size === "hero" ? "text-xs" : "text-[10px] sm:text-[11px]",
+        )}
+      >
+        {disclaimer}
+      </p>
+    </section>
+  );
+}

--- a/components/chat/chat-shell.tsx
+++ b/components/chat/chat-shell.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { AppSidebar } from "@/components/chat-sidebar";
+import { Separator } from "@/components/ui/separator";
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+import type { ChatSummary } from "@/hooks/use-chat-list";
+import { cn } from "@/lib/utils";
+
+type ChatShellProps = {
+  chats: ChatSummary[];
+  currentChatId?: string;
+  title: ReactNode;
+  toolbarEnd?: ReactNode;
+  children: ReactNode;
+  onDelete: (chatId: string) => Promise<void>;
+  onRename: (chatId: string, conversationName: string) => Promise<void>;
+  onDeleted?: (chatId: string) => void;
+  contentClassName?: string;
+};
+
+export function ChatShell({
+  chats,
+  currentChatId,
+  title,
+  toolbarEnd,
+  children,
+  onDelete,
+  onRename,
+  onDeleted,
+  contentClassName,
+}: ChatShellProps) {
+  return (
+    <SidebarProvider
+      style={{ minHeight: "calc(100vh - var(--app-header-height))" }}
+    >
+      <AppSidebar
+        chats={chats}
+        currentChatId={currentChatId}
+        onDelete={onDelete}
+        onRename={onRename}
+        onDeleted={onDeleted}
+      />
+      <SidebarInset className="h-[calc(100vh-var(--app-header-height))] min-h-[calc(100vh-var(--app-header-height))] overflow-hidden !bg-transparent">
+        <div className="flex h-full min-h-0 flex-col">
+          <header className="z-20 flex min-h-14 shrink-0 items-center gap-2 border-b border-sidebar-border bg-card/95 px-3 py-2 shadow-[0_2px_8px_hsl(var(--foreground)/0.06)] backdrop-blur supports-[backdrop-filter]:bg-card/85 sm:px-4">
+            <SidebarTrigger className="shrink-0" />
+            <Separator orientation="vertical" className="h-5" />
+            <div className="min-w-0 flex-1">
+              <h1
+                className="truncate font-serif text-base font-semibold text-foreground sm:text-lg"
+                dir="auto"
+              >
+                {title}
+              </h1>
+            </div>
+            {toolbarEnd}
+          </header>
+          <main className={cn("min-h-0 flex-1", contentClassName)}>{children}</main>
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/components/chat/chat-shortcuts.tsx
+++ b/components/chat/chat-shortcuts.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import { BookOpen, Church, Sprout } from "lucide-react";
+
+const shortcutClassName =
+  "badge--neutral inline-flex min-h-10 items-center gap-1.5 whitespace-normal px-3 py-2 text-start text-sm transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+export function ChatShortcuts() {
+  return (
+    <nav
+      aria-label="Calvinist Parrot features"
+      className="flex flex-wrap justify-center gap-2 lg:hidden landscape:hidden"
+    >
+      <Link href="/devotional" prefetch={false} className={shortcutClassName}>
+        <span
+          className="material-symbols-outlined"
+          style={{ fontSize: "1rem", lineHeight: 1 }}
+          aria-hidden="true"
+        >
+          candle
+        </span>
+        <span>Devotional</span>
+      </Link>
+      <Link href="/journal" prefetch={false} className={shortcutClassName}>
+        <BookOpen className="h-4 w-4" aria-hidden="true" />
+        <span>Journal</span>
+      </Link>
+      <Link href="/prayer-tracker" prefetch={false} className={shortcutClassName}>
+        <span
+          className="material-symbols-outlined"
+          style={{ fontSize: "1rem", lineHeight: 1 }}
+          aria-hidden="true"
+        >
+          folded_hands
+        </span>
+        <span>Prayer Tracker</span>
+      </Link>
+      <Link href="/kids-discipleship" prefetch={false} className={shortcutClassName}>
+        <Sprout className="h-4 w-4" aria-hidden="true" />
+        <span>Heritage</span>
+      </Link>
+      <Link href="/church-finder" prefetch={false} className={shortcutClassName}>
+        <Church className="h-4 w-4" aria-hidden="true" />
+        <span>Church Finder</span>
+      </Link>
+    </nav>
+  );
+}

--- a/components/chat/chat-turn.tsx
+++ b/components/chat/chat-turn.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useRef } from "react";
+import { AlertCircle, CircleStop } from "lucide-react";
+
+import { MarkdownWithBibleVerses } from "@/components/MarkdownWithBibleVerses";
+import { MessageActions } from "@/components/chat/message-actions";
+import { SourcesAndProcess } from "@/components/chat/sources-and-process";
+import { Button } from "@/components/ui/button";
+import { copySelectedMessageContent } from "@/lib/chat-copy";
+import type { ChatMessageRecord, ChatTurn as ChatTurnType } from "@/lib/chat-turns";
+
+type ChatTurnProps = {
+  turn: ChatTurnType;
+  onEdit: (message: ChatMessageRecord) => void;
+  onRetry: (turn: ChatTurnType) => void;
+};
+
+export function ChatTurn({ turn, onEdit, onRetry }: ChatTurnProps) {
+  const userContentRef = useRef<HTMLDivElement>(null);
+  const assistantContentRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <article
+      className="space-y-4 scroll-mt-20"
+      aria-label="Conversation turn"
+      data-request-id={turn.requestId ?? undefined}
+    >
+      {turn.user ? (
+        <section className="ms-auto w-fit max-w-[min(90%,42rem)]">
+          <div className="rounded-lg bg-user-message px-4 py-3 text-user-message-foreground shadow-sm">
+            <p className="mb-1 text-sm font-semibold">You</p>
+            <div
+              ref={userContentRef}
+              dir="auto"
+              className="break-words [&>*:last-child]:mb-0"
+              onCopy={(event) => {
+                if (userContentRef.current) {
+                  copySelectedMessageContent(
+                    event.nativeEvent,
+                    userContentRef.current,
+                  );
+                }
+              }}
+            >
+              <MarkdownWithBibleVerses content={turn.user.content} />
+            </div>
+          </div>
+          <div className="mt-1 flex justify-end">
+            <MessageActions
+              markdown={turn.user.content}
+              contentRef={userContentRef}
+              ariaLabel="Actions for your message"
+              onEdit={() => onEdit(turn.user!)}
+            />
+          </div>
+        </section>
+      ) : null}
+
+      <SourcesAndProcess sources={turn.sources} />
+
+      {turn.assistant ? (
+        <section className="max-w-[72ch]">
+          <div className="rounded-lg border border-border/70 bg-card/85 px-4 py-4 text-card-foreground shadow-sm sm:px-5">
+            <p className="mb-2 text-sm font-semibold text-accent">Parrot</p>
+            <div
+              ref={assistantContentRef}
+              dir="auto"
+              className="break-words leading-7 [&>*:last-child]:mb-0"
+              onCopy={(event) => {
+                if (assistantContentRef.current) {
+                  copySelectedMessageContent(
+                    event.nativeEvent,
+                    assistantContentRef.current,
+                  );
+                }
+              }}
+            >
+              <MarkdownWithBibleVerses content={turn.assistant.content} />
+            </div>
+          </div>
+          <div className="mt-1 flex justify-start">
+            <MessageActions
+              markdown={turn.assistant.content}
+              contentRef={assistantContentRef}
+              ariaLabel="Actions for Parrot's message"
+            />
+          </div>
+        </section>
+      ) : null}
+
+      {turn.failure ? (
+        <section
+          className="max-w-[72ch] rounded-lg border border-destructive/50 bg-destructive/10 p-4"
+          role="alert"
+        >
+          <div className="flex items-start gap-3">
+            <AlertCircle
+              className="mt-0.5 h-5 w-5 shrink-0 text-destructive"
+              aria-hidden="true"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="font-semibold text-foreground">
+                We couldn&apos;t finish this response.
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Your question is preserved. You can try this request again.
+              </p>
+              <Button
+                type="button"
+                size="sm"
+                className="mt-3 min-h-9"
+                onClick={() => onRetry(turn)}
+                disabled={!turn.requestId}
+              >
+                Retry
+              </Button>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {turn.stopped ? (
+        <section
+          className="max-w-[72ch] rounded-lg border border-border bg-muted/35 p-4"
+          aria-live="polite"
+        >
+          <div className="flex items-center gap-3 text-sm text-muted-foreground">
+            <CircleStop className="h-5 w-5 shrink-0" aria-hidden="true" />
+            Response stopped. You can send a new message when you are ready.
+          </div>
+        </section>
+      ) : null}
+    </article>
+  );
+}

--- a/components/chat/copy-menu.tsx
+++ b/components/chat/copy-menu.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import type { RefObject } from "react";
+import { useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, Copy } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  absolutizeMarkdownLinks,
+  markdownToPlainText,
+  sanitizeClipboardHtml,
+  writeFormattedClipboard,
+} from "@/lib/chat-copy";
+
+type CopyFormat = "formatted" | "markdown" | "plain";
+
+type CopyMenuProps = {
+  markdown: string;
+  contentRef: RefObject<HTMLElement | null>;
+};
+
+const FEEDBACK_DURATION_MS = 2200;
+
+export function CopyMenu({ markdown, contentRef }: CopyMenuProps) {
+  const [feedback, setFeedback] = useState<string>("");
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current);
+    },
+    [],
+  );
+
+  const showFeedback = (message: string) => {
+    setFeedback(message);
+    if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current);
+    timeoutRef.current = window.setTimeout(() => {
+      setFeedback("");
+      timeoutRef.current = null;
+    }, FEEDBACK_DURATION_MS);
+  };
+
+  const copy = async (format: CopyFormat) => {
+    try {
+      const baseUrl = window.location.origin;
+      const markdownWithAbsoluteLinks = absolutizeMarkdownLinks(
+        markdown,
+        baseUrl,
+      );
+      const plainText = markdownToPlainText(markdown, { baseUrl });
+      if (format === "formatted") {
+        const html = sanitizeClipboardHtml(
+          contentRef.current?.innerHTML ?? `<p>${plainText}</p>`,
+          {
+            lang: document.documentElement.lang,
+            dir: "auto",
+            baseUrl,
+          },
+        );
+        await writeFormattedClipboard(html, plainText);
+        showFeedback("Formatted copy ready.");
+      } else if (format === "markdown") {
+        await navigator.clipboard.writeText(markdownWithAbsoluteLinks);
+        showFeedback("Markdown copied.");
+      } else {
+        await navigator.clipboard.writeText(plainText);
+        showFeedback("Plain text copied.");
+      }
+    } catch (error) {
+      console.error("Unable to copy message:", error);
+      showFeedback("Copy failed. Check your browser clipboard permission.");
+    }
+  };
+
+  const copied = feedback.endsWith("copied.") || feedback.endsWith("ready.");
+
+  return (
+    <div
+      className="inline-flex items-stretch"
+      data-clipboard-exclude
+    >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-9 min-h-9 w-9 rounded-e-none"
+            onClick={() => void copy("formatted")}
+            aria-label={copied ? feedback : "Copy formatted for Word"}
+          >
+            {copied ? (
+              <Check className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <Copy className="h-4 w-4" aria-hidden="true" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          {copied ? feedback : "Copy formatted for Word"}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-9 min-h-9 w-8 rounded-s-none border-s border-border/60"
+                aria-label="Choose copy format"
+              >
+                <ChevronDown className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Choose copy format</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="start" className="max-w-64">
+          <DropdownMenuItem
+            className="whitespace-normal"
+            onSelect={() => void copy("formatted")}
+          >
+            Formatted for Word
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => void copy("markdown")}>
+            Markdown
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => void copy("plain")}>
+            Plain text
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <span className="sr-only" aria-live="polite">
+        {feedback}
+      </span>
+    </div>
+  );
+}

--- a/components/chat/denomination-context-menu.tsx
+++ b/components/chat/denomination-context-menu.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronDown, Info } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+type DenominationContextMenuProps = {
+  denomination: string;
+  isAuthenticated: boolean;
+};
+
+function formatDenomination(value: string) {
+  return value
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function DenominationContextMenu({
+  denomination,
+  isAuthenticated,
+}: DenominationContextMenuProps) {
+  const label = formatDenomination(denomination);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="hidden h-auto min-h-9 max-w-64 whitespace-normal text-end lg:inline-flex"
+          aria-label={`About the ${label} conversation context`}
+        >
+          {label} context
+          <ChevronDown className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-80 space-y-4"
+        role="dialog"
+        aria-label="Conversation theological context"
+      >
+        <div className="flex items-start gap-3">
+          <Info
+            className="mt-0.5 h-5 w-5 shrink-0 text-primary"
+            aria-hidden="true"
+          />
+          <div className="space-y-2">
+            <h2 className="font-serif text-base font-semibold">
+              {label} context
+            </h2>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              Parrot uses this preference when a question touches secondary
+              doctrines such as baptism, church government, or spiritual
+              gifts. Its core Christian commitments remain unchanged.
+            </p>
+          </div>
+        </div>
+        <Button asChild className="w-full whitespace-normal">
+          <Link href={isAuthenticated ? "/profile" : "/register"}>
+            {isAuthenticated
+              ? "Go to profile to change it"
+              : "Create a profile to change it"}
+          </Link>
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/chat/edit-message-dialog.tsx
+++ b/components/chat/edit-message-dialog.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Textarea } from "@/components/ui/textarea";
+import { useIsMobile } from "@/hooks/use-mobile";
+import type { ChatMessageRecord } from "@/lib/chat-turns";
+
+type EditMessageDialogProps = {
+  message: ChatMessageRecord | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (message: ChatMessageRecord, editedText: string) => Promise<void>;
+};
+
+export function EditMessageDialog({
+  message,
+  open,
+  onOpenChange,
+  onConfirm,
+}: EditMessageDialogProps) {
+  const isMobile = useIsMobile(640);
+  const [value, setValue] = useState("");
+  const [confirming, setConfirming] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    setValue(message?.content ?? "");
+    setConfirming(false);
+    setIsSubmitting(false);
+    setError("");
+  }, [message, open]);
+
+  const submitBranch = async () => {
+    if (!message || !value.trim()) return;
+    setIsSubmitting(true);
+    setError("");
+    try {
+      await onConfirm(message, value.trim());
+      onOpenChange(false);
+    } catch (branchError) {
+      console.error("Unable to create conversation branch:", branchError);
+      setError("We could not create the new conversation. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const body = (
+    <>
+      {!confirming ? (
+        <Textarea
+          autoFocus
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          className="min-h-36 max-h-[50vh] resize-y bg-input-bg text-base"
+          dir="auto"
+          aria-label="Edit message"
+        />
+      ) : (
+        <div className="rounded-lg border border-primary/35 border-s-4 border-s-primary bg-card p-4 text-sm shadow-sm">
+          <p>
+            Editing this message will create a new conversation from this point.
+            Your original conversation will stay unchanged.
+          </p>
+          <p className="mt-2 text-muted-foreground">
+            The new title will be based on your edited message.
+          </p>
+        </div>
+      )}
+      {error ? (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </>
+  );
+
+  const actions = (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => onOpenChange(false)}
+        disabled={isSubmitting}
+      >
+        Cancel
+      </Button>
+      {!confirming ? (
+        <Button
+          type="button"
+          onClick={() => setConfirming(true)}
+          disabled={!value.trim() || value.trim() === message?.content.trim()}
+        >
+          Continue
+        </Button>
+      ) : (
+        <Button
+          type="button"
+          onClick={() => void submitBranch()}
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? (
+            <Loader2
+              className="h-4 w-4 animate-spin motion-reduce:animate-none"
+              aria-hidden="true"
+            />
+          ) : null}
+          Edit and create new
+        </Button>
+      )}
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent
+          side="bottom"
+          className="max-h-[90vh] overflow-y-auto rounded-t-[var(--radius)] pb-[max(1.5rem,env(safe-area-inset-bottom))]"
+        >
+          <SheetHeader className="text-start">
+            <SheetTitle>
+              {confirming ? "Create a new conversation?" : "Edit message"}
+            </SheetTitle>
+            <SheetDescription>
+              {confirming
+                ? "Your current conversation will not be changed."
+                : "Revise your question before creating a new branch."}
+            </SheetDescription>
+          </SheetHeader>
+          <div className="space-y-4 py-4">{body}</div>
+          <SheetFooter className="gap-2">{actions}</SheetFooter>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {confirming ? "Create a new conversation?" : "Edit message"}
+          </DialogTitle>
+          <DialogDescription>
+            {confirming
+              ? "Your current conversation will not be changed."
+              : "Revise your question before creating a new branch."}
+          </DialogDescription>
+        </DialogHeader>
+        {body}
+        <DialogFooter className="gap-2">{actions}</DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/chat/message-actions.tsx
+++ b/components/chat/message-actions.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import type { RefObject } from "react";
+import { Pencil } from "lucide-react";
+
+import { CopyMenu } from "@/components/chat/copy-menu";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+type MessageActionsProps = {
+  markdown: string;
+  contentRef: RefObject<HTMLElement | null>;
+  ariaLabel: string;
+  onEdit?: () => void;
+};
+
+export function MessageActions({
+  markdown,
+  contentRef,
+  ariaLabel,
+  onEdit,
+}: MessageActionsProps) {
+  return (
+    <TooltipProvider delayDuration={350}>
+      <div
+        className="flex flex-wrap items-center gap-1 text-muted-foreground"
+        data-clipboard-exclude
+        role="group"
+        aria-label={ariaLabel}
+      >
+        <CopyMenu markdown={markdown} contentRef={contentRef} />
+        {onEdit ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-9 min-h-9 w-9"
+                onClick={onEdit}
+                aria-label="Edit message"
+              >
+                <Pencil className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Edit message</TooltipContent>
+          </Tooltip>
+        ) : null}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/components/chat/sources-and-process.tsx
+++ b/components/chat/sources-and-process.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useId, useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+import { MarkdownWithBibleVerses } from "@/components/MarkdownWithBibleVerses";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import type { ChatMessageRecord } from "@/lib/chat-turns";
+
+type SourcesAndProcessProps = {
+  sources: ChatMessageRecord[];
+};
+
+function sourceLabel(source: ChatMessageRecord) {
+  if (source.toolName) return source.toolName;
+  if (source.sender === "gotQuestions") return "Theological Research";
+  if (source.sender === "CCEL") return "CCEL Retrieval";
+  return "Source";
+}
+
+export function SourcesAndProcess({ sources }: SourcesAndProcessProps) {
+  const [open, setOpen] = useState(false);
+  const contentId = useId();
+
+  if (sources.length === 0) return null;
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="max-w-[72ch] rounded-lg border border-border/70 bg-muted/25"
+    >
+      <CollapsibleTrigger
+        className="flex min-h-11 w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-start text-sm font-medium text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-expanded={open}
+        aria-controls={contentId}
+      >
+        <span>
+          Sources &amp; process
+          <span className="ms-2 font-normal text-muted-foreground">
+            {sources.length}
+          </span>
+        </span>
+        <ChevronDown
+          className={`h-4 w-4 shrink-0 transition-transform motion-reduce:transition-none ${open ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent id={contentId}>
+        <div className="space-y-4 border-t border-border/70 px-3 py-3">
+          {sources.map((source) => (
+            <section key={source.id}>
+              <h3 className="mb-2 text-sm font-semibold text-accent">
+                {sourceLabel(source)}
+              </h3>
+              <div className="break-words text-sm text-foreground" dir="auto">
+                <MarkdownWithBibleVerses content={source.content} />
+              </div>
+            </section>
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/components/chat/suggested-questions.tsx
+++ b/components/chat/suggested-questions.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useId, useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+
+export const DEFAULT_SUGGESTED_QUESTIONS = [
+  "What does it mean to be justified by faith?",
+  "How should I pray when God feels distant?",
+  "How do God's sovereignty and human responsibility fit together?",
+  "What should I look for in a faithful local church?",
+];
+
+type SuggestedQuestionsProps = {
+  onSelect: (question: string) => void;
+  questions?: string[];
+};
+
+function QuestionList({
+  questions,
+  onSelect,
+}: {
+  questions: string[];
+  onSelect: (question: string) => void;
+}) {
+  return (
+    <div className="grid gap-2 lg:grid-cols-2">
+      {questions.map((question) => (
+        <Button
+          key={question}
+          type="button"
+          variant="ghost"
+          className="h-auto min-h-11 justify-start whitespace-normal border border-border/70 bg-card/45 px-3 py-2 text-start font-normal text-foreground hover:bg-card"
+          onClick={() => onSelect(question)}
+          dir="auto"
+        >
+          {question}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+export function SuggestedQuestions({
+  onSelect,
+  questions = DEFAULT_SUGGESTED_QUESTIONS,
+}: SuggestedQuestionsProps) {
+  const [open, setOpen] = useState(false);
+  const contentId = useId();
+
+  return (
+    <>
+      <div className="hidden lg:block">
+        <p className="mb-2 text-sm font-medium text-muted-foreground">
+          Suggested questions
+        </p>
+        <QuestionList questions={questions} onSelect={onSelect} />
+      </div>
+      <Collapsible open={open} onOpenChange={setOpen} className="lg:hidden">
+        <CollapsibleTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            className="min-h-11 w-full justify-between whitespace-normal bg-card/60 text-start"
+            aria-expanded={open}
+            aria-controls={contentId}
+          >
+            Suggested questions
+            <ChevronDown
+              className={`h-4 w-4 shrink-0 transition-transform motion-reduce:transition-none ${open ? "rotate-180" : ""}`}
+              aria-hidden="true"
+            />
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent id={contentId} className="pt-2">
+          <QuestionList questions={questions} onSelect={onSelect} />
+        </CollapsibleContent>
+      </Collapsible>
+    </>
+  );
+}

--- a/docs/design/Color System Mapping.md
+++ b/docs/design/Color System Mapping.md
@@ -9,7 +9,7 @@ This document maps the Brand Identity colors to their usage in the application's
 | Brand Color | Hex | HSL | CSS Variable | Usage in App |
 |------------|-----|-----|--------------|--------------|
 | **Deep Teal** | `#004D4D` | `180, 100%, 15%` | `--accent`<br>`--chart-2`<br>`.app-header text` | **Header text color**, links, accent elements, chart color |
-| **Deep Blue** | `#004D70` | `199, 100%, 22%` | `--primary`<br>`--parrot-message`<br>`--ring`<br>`--sidebar-ring` | Primary buttons, Parrot chat bubbles, focus rings |
+| **Deep Blue** | `#004D70` | `199, 100%, 22%` | `--primary`<br>`--parrot-message`<br>`--ring`<br>`--sidebar-ring` | Primary buttons, legacy/compact Parrot chat bubbles, focus rings |
 | **Warm Gold** | `#FFD166` | `42, 100%, 70%` | `--chart-1` | Charts, potential future highlight color |
 
 ### Accent Colors
@@ -24,13 +24,20 @@ This document maps the Brand Identity colors to their usage in the application's
 
 | Brand Color | Hex | HSL | CSS Variable | Usage in App |
 |------------|-----|-----|--------------|--------------|
-| **Cream** | `#F5EEDC` | `42, 56%, 91%` | `--background`<br>`--popover`<br>`--sidebar-background`<br>`.app-header background` | Warm main background, sidebar, header background (matches main site) |
-| **Off-White** | `#FAFAFA` | `0, 0%, 98%` | `--card` | Subtle card elevation |
+| **Cream** | `#F5EEDC` | `42, 56%, 91%` | `--background`<br>`--popover`<br>`.app-header background` | Warm main background and header background (matches main site) |
+| **Deep Cream** | token-derived | `42, 35%, 87%` | `--sidebar-background` | Light-mode chat sidebar separation |
+| **Off-White** | `#FAFAFA` | `0, 0%, 98%` | `--card` | Subtle card elevation, light-mode chat toolbars, long-form Parrot surfaces |
 | **Pure White** | `#FFFFFF` | `0, 0%, 100%` | `--primary-foreground`<br>`--accent-foreground`<br>`--parrot-message-foreground` | Text on colored buttons/elements |
 | **Charcoal** | `#333333` | `0, 0%, 20%` | `--foreground`<br>`--card-foreground`<br>`--user-message-foreground`<br>`--sidebar-primary` | Body text, headings |
-| **Light Gray** | `#E5E5E5` | `0, 0%, 90%` | `--border`<br>`--sidebar-border` | Borders, dividers |
+| **Light Gray** | `#E5E5E5` | `0, 0%, 90%` | `--border` | General borders and dividers |
+| **Warm Neutral** | token-derived | `42, 20%, 74%` | `--sidebar-border` | Light-mode sidebar and chat-toolbar dividers |
 | **Very Light Gray** | `#F5F5F5` | `0, 0%, 96%` | `--muted`<br>`--input`<br>`--secondary` | Muted backgrounds, input fields, secondary actions |
 | **Pure White** | `#FFFFFF` | `0, 0%, 100%` | `--input-bg` | Input backgrounds in light mode |
+
+`--input-bg` is the required surface token for the main chat composer. Pair it
+with `border-input` and subtle token-derived elevation; do not add a chat-only
+background color. In dark mode the same token maps to dark charcoal so the
+composer stays distinct without inheriting light-theme colors.
 
 ## Semantic Color Variables
 
@@ -58,11 +65,11 @@ In dark mode, brand colors are adjusted for better contrast and readability:
   - Accent: `180, 100%, 15%` → `180, 100%, 30%` (lighter Deep Teal)
   - Sidebar Accent: `172, 43%, 55%` → `172, 45%, 45%` (adjusted Mint Green)
   - Focus ring: `--ring` becomes near-white `0, 0%, 98%` for stronger contrast
-- **Message Bubbles**: Both inverted for consistency
+- **Message Surfaces**:
   - **User Messages**: Darker Sage Green `82, 25%, 35%` with white text
-  - **Parrot Messages**: Lighter Deep Blue `199, 100%, 35%` with white text
-  - Creates consistent visual pattern (both have dark backgrounds with light text)
-  - Better contrast and more elegant appearance
+  - **Long-form Parrot Answers**: Dark `--card` surface with `--card-foreground` text and a visible `--border` edge
+  - **Legacy/Compact Parrot Messages**: Lighter Deep Blue `199, 100%, 35%` with white text
+  - This keeps long theological answers quiet and readable while preserving the Deep Blue legacy treatment where a compact bubble is still appropriate
 - **Header**: 
   - Dark card background `0, 0%, 15%` instead of cream
   - White text instead of Deep Teal for better readability
@@ -94,7 +101,7 @@ In dark mode, brand colors are adjusted for better contrast and readability:
 
 Sidebar palette reference:
 
-- Light mode: `--sidebar-accent: 172, 43%, 55%`, `--sidebar-primary: 0, 0%, 20%`, `--sidebar-ring: 199, 100%, 22%`
+- Light mode: `--sidebar-background: 42, 35%, 87%`, `--sidebar-border: 42, 20%, 74%`, `--sidebar-accent: 172, 43%, 55%`, `--sidebar-primary: 0, 0%, 20%`, `--sidebar-ring: 199, 100%, 22%`
 - Dark mode: `--sidebar-accent: 172, 45%, 45%`, `--sidebar-primary: 199, 100%, 35%`, `--sidebar-ring: 199, 100%, 35%`
 
 ## Usage Guidelines
@@ -131,7 +138,7 @@ Use Tailwind's semantic color classes:
 
 ### Color Hierarchy
 
-1. **Primary** (Deep Blue): Main actions, CTAs, Parrot messages
+1. **Primary** (Deep Blue): Main actions, CTAs, and legacy/compact Parrot messages
 2. **Accent** (Deep Teal): Links, secondary emphasis
 3. **Success** (Green): Positive feedback, completed actions
 4. **Destructive** (Red): Errors, destructive actions
@@ -156,6 +163,8 @@ When making color changes or adding new components:
 - [ ] Check that shadows and borders are visible in both modes
 - [ ] Ensure sidebar active states use Mint Green (`--sidebar-accent`)
 - [ ] Confirm header styling matches main Calvinist Parrot Ministries site aesthetic
+- [ ] In light mode, confirm the Deep Cream sidebar, Off-White chat toolbar, and Cream content surface remain visibly distinct
+- [ ] Confirm branch/edit dialogs use a `--card` inset with a primary edge so the two light surfaces do not blend together
 
 ## Quick Reference: Common Patterns
 
@@ -184,13 +193,26 @@ When making color changes or adding new components:
 <Button className="bg-accent text-accent-foreground">Register</Button>
 ```
 
-### Message Bubbles (Chat Interface)
+### Message Surfaces (Chat Interface)
 ```tsx
 // User message
 <div className="bg-user-message text-user-message-foreground">User content</div>
 
-// Parrot/AI message
+// Preferred long-form Parrot/AI answer
+<article className="max-w-[72ch] border border-border bg-card text-card-foreground">
+  AI response
+</article>
+
+// Legacy or compact Parrot/AI message
 <div className="bg-parrot-message text-parrot-message-foreground">AI response</div>
+
+// Main chat composer
+<form className="border border-input bg-input-bg">...</form>
+
+// Edit/branch explanation inset
+<div className="border border-primary/35 border-s-4 border-s-primary bg-card">
+  Branching explanation
+</div>
 ```
 
 ### Cards and Containers

--- a/docs/design/Design System.md
+++ b/docs/design/Design System.md
@@ -174,6 +174,8 @@ All main feature pages use a standardized header pattern for consistency:
 
 - Inputs: `bg-background`/`bg-card`, `border-border`, focus `ring`.
 - Labels: `text-foreground/80`; helper text uses `muted-foreground`.
+- Long-form textareas should auto-grow until they reach a viewport-aware ceiling, then scroll internally. Use the shared `useAutoGrowingTextarea` behavior instead of fixed heights.
+- The New Journal Entry dialog keeps its header and action footer visible, lets the middle region scroll, and caps the textarea at `min(560px, 42dvh)` with a 200px minimum. This prevents long entries from pushing Cancel or Save Entry outside small phone viewports.
 
 ### 4.5 Cards
 
@@ -197,13 +199,29 @@ All main feature pages use a standardized header pattern for consistency:
 ### 4.8 Chat Bubbles
 
 - User: `bg-user-message text-user-message-foreground` (Sage)
-- Parrot: `bg-parrot-message text-parrot-message-foreground` (Deep Blue)
-- Maintain adequate padding and max-width for readability (~60–70ch max for prose).
+- Long-form Parrot answers: `bg-card text-card-foreground` with a subtle `border-border` edge. Keep the prose measure near `66–72ch`; this limits line length, never total answer length.
+- `bg-parrot-message text-parrot-message-foreground` (Deep Blue) remains available for legacy or compact assistant bubbles, but it is not the preferred surface for long-form answers.
+- Composer: `bg-input-bg border-input` with subtle elevation so it remains distinct from the Cream page and legible in dark mode. The landing composer is the entry screen’s visual anchor: it starts at 144px and auto-grows to `min(560px, 60vh)`. The in-conversation composer starts at 72px and auto-grows to `min(200px, 40vh)`.
+- Place message actions immediately outside both user and Parrot surfaces. Use icon-only controls with accessible names and tooltips to keep the transcript visually quiet.
+- Keep user and assistant content wrapped with `MarkdownWithBibleVerses` so headings, lists, tables, code, links, and Bible popovers retain their semantics.
+- The landing disclaimer is exactly: “The Parrot is not a substitute for your own study, prayer, or pastoral counsel.”
+- The in-conversation disclaimer is exactly: “The Parrot can make mistakes. Check important claims against Scripture and your elders/pastors.” Render it smaller than normal helper text.
+- Copy defaults to Formatted for Word and also offers Markdown and Plain text. All three formats resolve internal links to absolute URLs; selected rich text preserves semantic HTML with a plain-text fallback.
+- Editing a user message opens a clearly differentiated confirmation inset before creating a new conversation branch. The original conversation remains unchanged.
+- Denominational context controls explain what the context means before offering an explicit profile link; clicking the control must not navigate immediately.
+
+### 4.8.1 Chat Responsive Layout
+
+- The landing hero parrot is visible at widths of 390px and above and hidden below 390px.
+- Feature shortcuts stay anchored at the bottom of the landing content and remain tablet/phone-only with `lg:hidden landscape:hidden`.
+- Preserve the established shortcut icon set: Material Symbols `candle` and `folded_hands`, plus Lucide `BookOpen`, `Sprout`, and `Church`.
+- In light mode, use three related but distinct surfaces: Deep Cream for the sidebar, Off-White for the chat toolbar, and Cream for the main content. Reinforce their separation with the warm neutral sidebar border and subtle token-derived toolbar shadow.
 
 ### 4.9 Sidebar Navigation
 
 - Buttons: `.sidebar-button` with hover tint and active Mint background.
 - Colors: use `sidebar.*` tokens for background, foreground, accents, borders, ring.
+- In light mode, the sidebar uses a slightly deeper Cream and a warm neutral divider. Chat toolbars use the Off-White card surface so navigation, toolbar, and content remain distinct without introducing a new brand color.
 
 ### 4.10 Tables & Data
 
@@ -249,4 +267,6 @@ All main feature pages use a standardized header pattern for consistency:
 - Success text: `className="text-success"`
 - Warning chip: `className="status--warning"`
 - User bubble: `className="bg-user-message text-user-message-foreground"`
-- Parrot bubble: `className="bg-parrot-message text-parrot-message-foreground"`
+- Long-form Parrot answer: `className="max-w-[72ch] bg-card text-card-foreground border border-border"`
+- Legacy/compact Parrot bubble: `className="bg-parrot-message text-parrot-message-foreground"`
+- Chat composer: `className="bg-input-bg border-input"`

--- a/docs/plans/Internationalization-plan.md
+++ b/docs/plans/Internationalization-plan.md
@@ -90,6 +90,24 @@ Current regex (`[A-Z][a-zA-Z]+`) only matches Latin ASCII. Must support:
 
 **Strategy:** Per-locale regex patterns or a lookup-based approach instead of regex for non-Latin scripts.
 
+### Chat UX Must Not Depend on English Layout
+
+The main chat redesign must be localization-ready before translated routes ship. English copy length, Latin word boundaries, and left-to-right alignment must not become structural assumptions.
+
+- Size the composer, message actions, sidebar controls, prompt starters, status messages, and menus for translated labels that may expand by 30–50%.
+- Allow controls to wrap or move into an overflow menu instead of clipping or shrinking labels below accessible sizes.
+- Use CSS logical alignment (`start`/`end`, `ms`/`me`, `ps`/`pe`) for message placement, sidebar controls, action rows, and composer affordances.
+- Do not infer message ownership from physical left/right placement. Preserve semantic `user` and `assistant` roles, then map their visual alignment through the active text direction.
+- Use `dir="auto"` or isolated bidi spans where user prompts, AI answers, Bible references, URLs, code, or citations may contain mixed LTR and RTL text.
+- Keep answer width as a readable line measure (for example, `ch`/`max-width`) rather than limiting total response length. CJK and Arabic typography require locale-specific visual review rather than assuming an English character count produces the same measure.
+- Prompt starters must use flexible grid/list layouts and translated content keys; do not bake English prompt text into card dimensions.
+- Conversation titles, date groups, timestamps, copy feedback, streaming progress, error recovery, and accessibility announcements must all be localized.
+- Use `Intl.DateTimeFormat`, locale-aware case folding, and locale-aware search behavior for conversation grouping and sidebar search.
+- Composer keyboard help must be localized and must not assume every input method treats Enter, Shift, or composition events the same way. Never submit while an IME composition is active.
+- Rich clipboard output must preserve Unicode and semantic structure, include appropriate `lang`/`dir` metadata, and remove application theme colors so content pastes legibly into Word and Google Docs.
+- Manual selection copy, formatted copy, Markdown copy, and plain-text copy must be tested with non-Latin and RTL content.
+- The compact mobile chat header must prioritize space for navigation and the conversation title. Denomination context may appear persistently on desktop but must not require an additional mobile header row.
+
 ---
 
 ## Phase 0: Infrastructure Foundation (PR #1)
@@ -179,7 +197,14 @@ const notoSansArabic = Noto_Sans_Arabic({ weight: ["400","600"], variable: "--fo
   "common": { "loading", "error", "send", "cancel", "save", "delete", "back", "next", ... },
   "nav": { "chat", "devotional", "journal", "prayerTracker", "heritage", "churchFinder", "about", "labs", "login", "register", "more", "logout", "profile" },
   "home": { "subtitle": "What theological question do you have?", "placeholder": "Enter your question here...", "startChat": "Start Chat" },
-  "chat": { "you", "parrot", "typePlaceholder", "loadingChat", "copyMarkdown", "markdownCopied", "toolProgress.*", "toolTitles.*", ... },
+  "chat": {
+    "you", "parrot", "newChat", "searchConversations", "renameConversation",
+    "deleteConversation", "undoDelete", "typePlaceholder", "send", "stop",
+    "jumpToLatest", "loadingChat", "responseStopped", "retrySend",
+    "copyFormatted", "copyMarkdown", "copyPlainText", "formattedCopied",
+    "markdownCopied", "plainTextCopied", "copyFailed", "aiDisclaimer",
+    "promptStarters.*", "conversationGroups.*", "toolProgress.*", "toolTitles.*", ...
+  },
   "auth": { "loginTitle", "registerTitle", "email", "password", "forgotPassword", "noAccount", "hasAccount", ... },
   "seo": { "title", "description", "ogTitle", "ogDescription", ... }
 }
@@ -469,6 +494,10 @@ alternates: {
 - `components/chat-sidebar.tsx` - Sidebar position
 - `components/Header.tsx` - Navigation order, dropdown alignment
 - Chat message layout - User messages on correct side
+- Chat composer - Send/stop placement, safe-area padding, IME composition, and mixed-direction input
+- Message action menus - Logical alignment, translated labels, and 30–50% text expansion
+- Conversation search, rename, and date grouping - Locale-aware matching and formatting
+- Clipboard output - Preserve Unicode, semantic formatting, `lang`, and `dir` without copying theme colors
 
 **Verification:** Navigate to `/ar/` and `/ur/` - entire layout mirrors. Sidebar, navigation, chat messages, forms all render correctly RTL.
 
@@ -663,6 +692,10 @@ Key terms like "Justification by Faith", "Penal Substitutionary Atonement", "Per
 
 1. **Phase 0:** `npm run build` passes. All existing English URLs work identically. No visible changes.
 2. **Phase 1:** Toggle language selector through all 10 locales. Navigation, home page, chat basics display in correct language. Auth flow works.
+   - At 320px and 390px, long translated chat labels reflow or use an accessible overflow menu without clipping.
+   - Prompt starters, the conversation sidebar, message actions, and the composer remain usable with 30–50% string expansion.
+   - IME composition in Chinese, Hindi, Bengali, Arabic, and Urdu never submits prematurely.
+   - Formatted, Markdown, plain-text, and manual selection copy remain legible in Word and Google Docs and preserve non-Latin/RTL text.
 3. **Phase 2:** Bible verse popovers per locale:
    - `/es/` click "Romanos 8:28" -> shows `spa_rvg` (Reina Valera Gómez) text
    - `/zh/` click "罗马书 8:28" -> shows `cmn_cu1` (Chinese Union Simplified) text
@@ -671,6 +704,8 @@ Key terms like "Justification by Faith", "Penal Substitutionary Atonement", "Per
 4. **Phase 3:** Send chat question from `/es/`, `/zh/`, `/ar/` -> response in correct language with correct Bible book names and translation references.
 5. **Phase 4:** Google Rich Results Test passes for all locale variants. hreflang tags present and correct for all 10 locales.
 6. **Phase 5:** `/ar/` and `/ur/` render full RTL layout. Sidebar, navigation, chat, forms all mirror correctly.
+   - Mixed-direction Bible citations, URLs, code blocks, and copied content retain the correct reading order.
+   - Desktop may show denomination context within the existing chat header; mobile must not gain a second persistent header row.
 7. **Phase 6 (Church Finder):**
    - Submit a church in `/es/` -> AI extraction still returns English badge keys -> `filterAllowlistedBadges()` passes -> badges stored in DB
    - View same church evaluation in `/es/` -> status shows "Recomendado" (not "RECOMMENDED"), badges show translated display names

--- a/docs/technical/Local Development.md
+++ b/docs/technical/Local Development.md
@@ -43,6 +43,34 @@ The init script only runs when Docker creates the database volume. If you need t
 
 Do not put production credentials in `.env`. Keep production database credentials in Vercel and GitHub Environments only.
 
+### Codex worktrees
+
+Codex worktrees share the same Docker Postgres container and volume, but each worktree is provisioned with its own development, shadow, and test databases. The database names use a stable hash of `CODEX_WORKTREE_PATH`, so returning to the same worktree reconnects to the same isolated data while parallel worktrees cannot migrate or reset each other's databases.
+
+The local-environment setup runs:
+
+```bash
+docker compose up -d --wait postgres
+npm run db:worktree:setup
+npm run db:deploy
+npm run db:generate
+npm run db:seed
+```
+
+`db:worktree:setup` creates databases named like:
+
+```text
+calvinist_parrot_dev_a1b2c3d4e5f6
+calvinist_parrot_shadow_a1b2c3d4e5f6
+calvinist_parrot_test_a1b2c3d4e5f6
+```
+
+It then generates the worktree's `.env` from `.env.template`, replacing only the three local database URLs. To provide API keys and other local or staging credentials, create an ignored `.env.worktree.local` in the local checkout. The tracked `.worktreeinclude` copies it into new Codex-managed worktrees, and the setup copies it to `.env.local`. The setup rejects `DATABASE_URL`, `SHADOW_DATABASE_URL`, or `TEST_DATABASE_URL` in the credential overlay so it cannot replace the isolated local URLs. Never put a production database URL in that file.
+
+The isolated databases remain in the shared Docker volume after a worktree is removed so an accidental cleanup cannot destroy another active agent's data. `docker compose down` still stops the shared Postgres service for every worktree, and `docker compose down -v` deletes all local and worktree databases, so do not run those commands while another worktree is active.
+
+When two branches add migrations independently, rebase or merge them and validate the combined migration directory against a fresh database before production deployment. Database isolation prevents local interference, but it does not resolve conflicting SQL or migration ordering automatically.
+
 ## Migrations
 
 Use `npm run db:migrate` locally after changing `prisma/schema.prisma`. This should target the Docker database from `.env`.

--- a/hooks/use-auto-growing-textarea.ts
+++ b/hooks/use-auto-growing-textarea.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type FormEvent,
+} from "react";
+
+type AutoGrowingTextareaOptions = {
+  minHeight: number;
+  maxHeight: number;
+  maxViewportRatio?: number;
+  enabled?: boolean;
+};
+
+export function useAutoGrowingTextarea(
+  value: string,
+  {
+    minHeight,
+    maxHeight,
+    maxViewportRatio = 0.6,
+    enabled = true,
+  }: AutoGrowingTextareaOptions,
+) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const resizeTextarea = useCallback(
+    (textarea: HTMLTextAreaElement | null = textareaRef.current) => {
+      if (!enabled || !textarea) return;
+
+      const viewportHeight =
+        typeof window === "undefined" ? maxHeight : window.innerHeight;
+      const responsiveMaximum = Math.max(
+        minHeight,
+        Math.min(maxHeight, viewportHeight * maxViewportRatio),
+      );
+
+      textarea.style.height = "auto";
+      const nextHeight = Math.min(
+        Math.max(textarea.scrollHeight, minHeight),
+        responsiveMaximum,
+      );
+      textarea.style.height = `${nextHeight}px`;
+      textarea.style.overflowY =
+        textarea.scrollHeight > responsiveMaximum ? "auto" : "hidden";
+    },
+    [enabled, maxHeight, maxViewportRatio, minHeight],
+  );
+
+  useEffect(() => {
+    resizeTextarea();
+  }, [resizeTextarea, value]);
+
+  useEffect(() => {
+    const handleViewportChange = () => resizeTextarea();
+    window.addEventListener("resize", handleViewportChange);
+    return () => window.removeEventListener("resize", handleViewportChange);
+  }, [resizeTextarea]);
+
+  const handleInput = useCallback(
+    (event: FormEvent<HTMLTextAreaElement>) => {
+      resizeTextarea(event.currentTarget);
+    },
+    [resizeTextarea],
+  );
+
+  return { textareaRef, handleInput };
+}

--- a/hooks/use-chat-list.ts
+++ b/hooks/use-chat-list.ts
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 export type ChatSummary = {
   id: string;
   conversationName: string;
+  modifiedAt: string;
 };
 
 async function loadChats(): Promise<ChatSummary[]> {
@@ -29,15 +30,28 @@ export function useChatList(actorKey: string) {
   });
 
   const upsertChat = useCallback(
-    (chat: ChatSummary) => {
+    (
+      chat: Omit<ChatSummary, "modifiedAt"> &
+        Partial<Pick<ChatSummary, "modifiedAt">>,
+    ) => {
       queryClient.setQueryData<ChatSummary[]>(queryKey, (current = []) => {
         const existingIndex = current.findIndex((item) => item.id === chat.id);
         if (existingIndex !== -1) {
           const next = current.slice();
-          next[existingIndex] = chat;
+          next[existingIndex] = {
+            ...next[existingIndex],
+            ...chat,
+            modifiedAt: chat.modifiedAt ?? new Date().toISOString(),
+          };
           return next;
         }
-        return [chat, ...current];
+        return [
+          {
+            ...chat,
+            modifiedAt: chat.modifiedAt ?? new Date().toISOString(),
+          },
+          ...current,
+        ];
       });
     },
     [queryClient, queryKey],
@@ -61,6 +75,7 @@ export function useChatList(actorKey: string) {
       variables: {
         initialQuestion: string;
         clientChatId?: string;
+        requestId?: string;
       },
     ) => {
       const response = await fetch("/api/parrot-chat", {
@@ -71,12 +86,77 @@ export function useChatList(actorKey: string) {
       if (!response.ok) {
         throw new Error("Failed to create chat session");
       }
-      const json = (await response.json()) as { chatId?: string };
-      if (!json.chatId) {
+      const json = (await response.json()) as {
+        chatId?: string;
+        messageId?: string;
+        requestId?: string;
+      };
+      if (!json.chatId || !json.messageId || !json.requestId) {
         throw new Error("Chat session created without an ID");
       }
-      return { chatId: json.chatId };
+      return {
+        chatId: json.chatId,
+        messageId: json.messageId,
+        requestId: json.requestId,
+      };
     },
+  });
+
+  const renameMutation = useMutation({
+    mutationFn: async ({
+      chatId,
+      conversationName,
+    }: {
+      chatId: string;
+      conversationName: string;
+    }) => {
+      const response = await fetch("/api/user-chats", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chatId, conversationName }),
+      });
+      if (!response.ok) throw new Error("Failed to rename conversation");
+      return (await response.json()) as { chat: ChatSummary };
+    },
+    onMutate: async ({ chatId, conversationName }) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<ChatSummary[]>(queryKey);
+      queryClient.setQueryData<ChatSummary[]>(queryKey, (current = []) =>
+        current.map((chat) =>
+          chat.id === chatId
+            ? { ...chat, conversationName, modifiedAt: new Date().toISOString() }
+            : chat,
+        ),
+      );
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) queryClient.setQueryData(queryKey, context.previous);
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (chatId: string) => {
+      const params = new URLSearchParams({ chatId });
+      const response = await fetch(`/api/user-chats?${params.toString()}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) throw new Error("Failed to delete conversation");
+      return chatId;
+    },
+    onMutate: async (chatId) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<ChatSummary[]>(queryKey);
+      queryClient.setQueryData<ChatSummary[]>(queryKey, (current = []) =>
+        current.filter((chat) => chat.id !== chatId),
+      );
+      return { previous };
+    },
+    onError: (_error, _chatId, context) => {
+      if (context?.previous) queryClient.setQueryData(queryKey, context.previous);
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey }),
   });
 
   return {
@@ -90,5 +170,7 @@ export function useChatList(actorKey: string) {
     removeChat,
     invalidate,
     createChat: createMutation,
+    renameChat: renameMutation,
+    deleteChat: deleteMutation,
   };
 }

--- a/lib/chat-context.test.ts
+++ b/lib/chat-context.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_CHAT_DENOMINATION,
+  resolveEffectiveDenomination,
+} from "./chat-context";
+
+describe("effective chat denomination", () => {
+  it("uses the authenticated profile preference before the chat fallback", () => {
+    expect(
+      resolveEffectiveDenomination("presbyterian", "reformed-baptist"),
+    ).toBe("presbyterian");
+  });
+
+  it("uses the chat denomination when no profile preference exists", () => {
+    expect(resolveEffectiveDenomination(null, "anglican")).toBe("anglican");
+  });
+
+  it("falls back to the application default when both values are absent", () => {
+    expect(resolveEffectiveDenomination(null, null)).toBe(
+      DEFAULT_CHAT_DENOMINATION,
+    );
+  });
+});

--- a/lib/chat-context.ts
+++ b/lib/chat-context.ts
@@ -1,0 +1,12 @@
+export const DEFAULT_CHAT_DENOMINATION = "reformed-baptist";
+
+export function resolveEffectiveDenomination(
+  profileDenomination?: string | null,
+  chatDenomination?: string | null,
+): string {
+  return (
+    profileDenomination?.trim() ||
+    chatDenomination?.trim() ||
+    DEFAULT_CHAT_DENOMINATION
+  );
+}

--- a/lib/chat-copy.test.ts
+++ b/lib/chat-copy.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+
+import {
+  absolutizeMarkdownLinks,
+  markdownToPlainText,
+  sanitizeClipboardHtml,
+} from "./chat-copy";
+
+describe("chat clipboard formatting", () => {
+  it("preserves semantic content without application theme styling", () => {
+    const result = sanitizeClipboardHtml(`
+      <div class="bg-parrot-message text-white" style="color:white">
+        <h2>Grace</h2>
+        <p>Saved by <strong>faith</strong>.</p>
+        <button>John 3:16</button>
+        <script>privatePayload()</script>
+      </div>
+    `);
+
+    expect(result).toContain("<h2>Grace</h2>");
+    expect(result).toContain("<strong>faith</strong>");
+    expect(result).toContain("John 3:16");
+    expect(result).toContain("color:#000");
+    expect(result).not.toContain("text-white");
+    expect(result).not.toContain("bg-parrot-message");
+    expect(result).not.toContain("color:white");
+    expect(result).not.toContain("privatePayload");
+  });
+
+  it("preserves Unicode and bidirectional metadata", () => {
+    const result = sanitizeClipboardHtml(
+      "<p>النعمة — 恩典 — grace</p>",
+      { lang: "ar", dir: "auto" },
+    );
+
+    expect(result).toContain('lang="ar"');
+    expect(result).toContain('dir="auto"');
+    expect(result).toContain("النعمة — 恩典 — grace");
+  });
+
+  it("creates readable plain text from Markdown", () => {
+    expect(
+      markdownToPlainText(
+        "## Hope\n\n- **Grace**\n- [Scripture](https://example.com)",
+      ),
+    ).toBe("Hope\n\n• Grace\n• Scripture (https://example.com)");
+  });
+
+  it("uses absolute URLs for links in every clipboard format", () => {
+    const markdown = "[Church Finder](/church-finder)";
+    const baseUrl = "http://localhost:3000";
+
+    expect(absolutizeMarkdownLinks(markdown, baseUrl)).toBe(
+      "[Church Finder](http://localhost:3000/church-finder)",
+    );
+    expect(markdownToPlainText(markdown, { baseUrl })).toBe(
+      "Church Finder (http://localhost:3000/church-finder)",
+    );
+    expect(
+      sanitizeClipboardHtml('<a href="/church-finder">Church Finder</a>', {
+        baseUrl,
+      }),
+    ).toContain('href="http://localhost:3000/church-finder"');
+  });
+});

--- a/lib/chat-copy.ts
+++ b/lib/chat-copy.ts
@@ -1,0 +1,245 @@
+const ALLOWED_ELEMENTS = new Set([
+  "A",
+  "BLOCKQUOTE",
+  "BR",
+  "CODE",
+  "DIV",
+  "EM",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "H5",
+  "H6",
+  "HR",
+  "LI",
+  "OL",
+  "P",
+  "PRE",
+  "SPAN",
+  "STRONG",
+  "TABLE",
+  "TBODY",
+  "TD",
+  "TH",
+  "THEAD",
+  "TR",
+  "UL",
+]);
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function toAbsoluteClipboardUrl(url: string, baseUrl?: string) {
+  const trimmedUrl = url.trim();
+  if (
+    !baseUrl ||
+    !trimmedUrl ||
+    /^\s*(?:javascript|data):/i.test(trimmedUrl)
+  ) {
+    return trimmedUrl;
+  }
+
+  try {
+    return new URL(trimmedUrl, baseUrl).href;
+  } catch {
+    return trimmedUrl;
+  }
+}
+
+export function absolutizeMarkdownLinks(markdown: string, baseUrl?: string) {
+  if (!baseUrl) return markdown;
+
+  return markdown.replace(
+    /(!?\[[^\]]*\]\()(\s*)(<[^>\n]+>|[^\s)\n]+)([^)\n]*\))/g,
+    (match, opening, spacing, destination, closing) => {
+      const usesAngles = destination.startsWith("<") && destination.endsWith(">");
+      const rawUrl = usesAngles ? destination.slice(1, -1) : destination;
+      const absoluteUrl = toAbsoluteClipboardUrl(rawUrl, baseUrl);
+      if (!absoluteUrl || absoluteUrl === rawUrl) return match;
+      const resolvedDestination = usesAngles ? `<${absoluteUrl}>` : absoluteUrl;
+      return `${opening}${spacing}${resolvedDestination}${closing}`;
+    },
+  );
+}
+
+export function markdownToPlainText(
+  markdown: string,
+  options: { baseUrl?: string } = {},
+) {
+  return absolutizeMarkdownLinks(markdown, options.baseUrl)
+    .replace(/```(?:\w+)?\n?([\s\S]*?)```/g, "$1")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 ($2)")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^>\s?/gm, "")
+    .replace(/^[-*+]\s+/gm, "• ")
+    .replace(/^\d+\.\s+/gm, "")
+    .replace(/(\*\*|__)(.*?)\1/g, "$2")
+    .replace(/(\*|_)(.*?)\1/g, "$2")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function unwrapElement(element: Element) {
+  const parent = element.parentNode;
+  if (!parent) return;
+  while (element.firstChild) {
+    parent.insertBefore(element.firstChild, element);
+  }
+  parent.removeChild(element);
+}
+
+function addNeutralSemanticStyles(element: Element) {
+  const tag = element.tagName;
+  if (tag === "TABLE") {
+    element.setAttribute(
+      "style",
+      "border-collapse:collapse;width:100%;color:#000;background:#fff;",
+    );
+  } else if (tag === "TH" || tag === "TD") {
+    element.setAttribute(
+      "style",
+      "border:1px solid #999;padding:6px;text-align:start;color:#000;background:#fff;",
+    );
+  } else if (tag === "PRE") {
+    element.setAttribute(
+      "style",
+      "white-space:pre-wrap;font-family:monospace;color:#000;background:#f5f5f5;padding:8px;",
+    );
+  } else if (tag === "CODE") {
+    element.setAttribute("style", "font-family:monospace;color:#000;");
+  } else if (tag === "BLOCKQUOTE") {
+    element.setAttribute(
+      "style",
+      "border-inline-start:3px solid #999;margin-inline-start:0;padding-inline-start:12px;color:#000;",
+    );
+  }
+}
+
+export function sanitizeClipboardHtml(
+  html: string,
+  options: {
+    lang?: string;
+    dir?: "auto" | "ltr" | "rtl";
+    baseUrl?: string;
+  } = {},
+) {
+  const lang = options.lang?.trim() || "en";
+  const dir = options.dir ?? "auto";
+
+  if (typeof DOMParser === "undefined") {
+    const plainText = html.replace(/<[^>]*>/g, " ");
+    return `<div lang="${escapeHtml(lang)}" dir="${dir}" style="color:#000;background:#fff;">${escapeHtml(plainText)}</div>`;
+  }
+
+  const document = new DOMParser().parseFromString(html, "text/html");
+  document
+    .querySelectorAll(
+      "script,style,svg,canvas,iframe,noscript,[hidden],[aria-hidden='true'],[data-clipboard-exclude]",
+    )
+    .forEach((element) => element.remove());
+
+  Array.from(document.body.querySelectorAll("*")).forEach((element) => {
+    if (element.tagName === "BUTTON") {
+      unwrapElement(element);
+      return;
+    }
+    if (!ALLOWED_ELEMENTS.has(element.tagName)) {
+      unwrapElement(element);
+      return;
+    }
+
+    const href = element.tagName === "A" ? element.getAttribute("href") : null;
+    const elementLang = element.getAttribute("lang");
+    const elementDir = element.getAttribute("dir");
+    Array.from(element.attributes).forEach((attribute) => {
+      element.removeAttribute(attribute.name);
+    });
+
+    if (href && !/^\s*javascript:/i.test(href)) {
+      element.setAttribute(
+        "href",
+        toAbsoluteClipboardUrl(href, options.baseUrl),
+      );
+    }
+    if (elementLang) element.setAttribute("lang", elementLang);
+    if (elementDir === "ltr" || elementDir === "rtl" || elementDir === "auto") {
+      element.setAttribute("dir", elementDir);
+    }
+    addNeutralSemanticStyles(element);
+  });
+
+  return `<div lang="${escapeHtml(lang)}" dir="${dir}" style="color:#000;background:#fff;font-family:Arial,sans-serif;">${document.body.innerHTML}</div>`;
+}
+
+export async function writeFormattedClipboard(html: string, plainText: string) {
+  if (
+    typeof navigator !== "undefined" &&
+    navigator.clipboard?.write &&
+    typeof ClipboardItem !== "undefined"
+  ) {
+    const item = new ClipboardItem({
+      "text/html": new Blob([html], { type: "text/html" }),
+      "text/plain": new Blob([plainText], { type: "text/plain" }),
+    });
+    await navigator.clipboard.write([item]);
+    return;
+  }
+
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(plainText);
+    return;
+  }
+
+  throw new Error("Clipboard access is unavailable.");
+}
+
+export function copySelectedMessageContent(
+  event: ClipboardEvent,
+  messageElement: HTMLElement,
+) {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return false;
+  }
+
+  const range = selection.getRangeAt(0);
+  try {
+    if (!range.intersectsNode(messageElement)) return false;
+  } catch {
+    return false;
+  }
+
+  const fragment = range.cloneContents();
+  const wrapper = document.createElement("div");
+  wrapper.appendChild(fragment);
+  const plainTextWrapper = wrapper.cloneNode(true) as HTMLDivElement;
+  plainTextWrapper.querySelectorAll("a[href]").forEach((anchor) => {
+    const href = toAbsoluteClipboardUrl(
+      anchor.getAttribute("href") ?? "",
+      window.location.origin,
+    );
+    if (!href) return;
+    anchor.replaceWith(
+      document.createTextNode(`${anchor.textContent ?? ""} (${href})`),
+    );
+  });
+  const plainText = plainTextWrapper.textContent || selection.toString();
+  const html = sanitizeClipboardHtml(wrapper.innerHTML, {
+    lang: document.documentElement.lang,
+    dir: "auto",
+    baseUrl: window.location.origin,
+  });
+
+  event.preventDefault();
+  event.clipboardData?.setData("text/html", html);
+  event.clipboardData?.setData("text/plain", plainText);
+  return true;
+}

--- a/lib/chat-list.test.ts
+++ b/lib/chat-list.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { chatTitleMatches, groupChatsByDate } from "./chat-list";
+
+describe("conversation list helpers", () => {
+  it("groups conversations relative to the locale's current day", () => {
+    const groups = groupChatsByDate(
+      [
+        {
+          id: "today",
+          conversationName: "Today",
+          modifiedAt: "2026-07-25T08:00:00.000Z",
+        },
+        {
+          id: "week",
+          conversationName: "This week",
+          modifiedAt: "2026-07-22T12:00:00.000Z",
+        },
+        {
+          id: "older",
+          conversationName: "Older",
+          modifiedAt: "2026-07-01T12:00:00.000Z",
+        },
+      ],
+      new Date("2026-07-25T12:00:00.000Z"),
+    );
+
+    expect(groups.map((group) => group.label)).toEqual([
+      "Today",
+      "Previous 7 days",
+      "Older",
+    ]);
+    expect(groups.map((group) => group.chats[0].id)).toEqual([
+      "today",
+      "week",
+      "older",
+    ]);
+  });
+
+  it("matches titles with locale-aware case folding and diacritics", () => {
+    expect(chatTitleMatches("Église fidèle", "eglise", "fr")).toBe(true);
+    expect(chatTitleMatches("Istanbul", "ıstanbul", "tr")).toBe(true);
+    expect(chatTitleMatches("Justification", "sanctification", "en")).toBe(false);
+  });
+});

--- a/lib/chat-list.ts
+++ b/lib/chat-list.ts
@@ -1,0 +1,54 @@
+import type { ChatSummary } from "@/hooks/use-chat-list";
+
+export type ChatDateGroup = {
+  key: "today" | "previous-seven-days" | "older";
+  label: "Today" | "Previous 7 days" | "Older";
+  chats: ChatSummary[];
+};
+
+function normalizeForSearch(value: string, locale: string) {
+  return value
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .toLocaleLowerCase(locale)
+    .trim();
+}
+
+export function chatTitleMatches(
+  title: string,
+  query: string,
+  locale = "en",
+) {
+  const normalizedQuery = normalizeForSearch(query, locale);
+  if (!normalizedQuery) return true;
+  return normalizeForSearch(title, locale).includes(normalizedQuery);
+}
+
+export function groupChatsByDate(
+  chats: ChatSummary[],
+  now = new Date(),
+): ChatDateGroup[] {
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+  const previousSevenDays = new Date(startOfToday);
+  previousSevenDays.setDate(previousSevenDays.getDate() - 7);
+
+  const groups: ChatDateGroup[] = [
+    { key: "today", label: "Today", chats: [] },
+    { key: "previous-seven-days", label: "Previous 7 days", chats: [] },
+    { key: "older", label: "Older", chats: [] },
+  ];
+
+  for (const chat of chats) {
+    const modifiedAt = new Date(chat.modifiedAt);
+    if (!Number.isFinite(modifiedAt.getTime()) || modifiedAt < previousSevenDays) {
+      groups[2].chats.push(chat);
+    } else if (modifiedAt < startOfToday) {
+      groups[1].chats.push(chat);
+    } else {
+      groups[0].chats.push(chat);
+    }
+  }
+
+  return groups.filter((group) => group.chats.length > 0);
+}

--- a/lib/chat-request-state.test.ts
+++ b/lib/chat-request-state.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getRequestTerminalState,
+  selectTerminalSafeMessages,
+} from "./chat-request-state";
+
+describe("chat request terminal state", () => {
+  it("treats a completed answer as terminal", () => {
+    expect(
+      getRequestTerminalState([
+        { sender: "user" },
+        { sender: "system_stopped" },
+        { sender: "parrot" },
+      ]),
+    ).toBe("completed");
+  });
+
+  it("drops a queued answer after a stop has already won", () => {
+    expect(
+      selectTerminalSafeMessages(
+        [
+          { sender: "tool_summary", content: "Source" },
+          { sender: "parrot", content: "Completed answer" },
+        ],
+        "stopped",
+        false,
+      ),
+    ).toEqual([{ sender: "tool_summary", content: "Source" }]);
+  });
+
+  it("persists the stop marker instead of a queued answer when stopping wins", () => {
+    expect(
+      selectTerminalSafeMessages(
+        [
+          { sender: "tool_summary", content: "Source" },
+          { sender: "parrot", content: "Completed answer" },
+          { sender: "system_stopped", content: "Stopped" },
+        ],
+        "open",
+        true,
+      ),
+    ).toEqual([
+      { sender: "tool_summary", content: "Source" },
+      { sender: "system_stopped", content: "Stopped" },
+    ]);
+  });
+
+  it("does not add a stop marker after completion has already won", () => {
+    expect(
+      selectTerminalSafeMessages(
+        [{ sender: "system_stopped", content: "Stopped" }],
+        "completed",
+        true,
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not persist a later failure after completion has already won", () => {
+    expect(
+      selectTerminalSafeMessages(
+        [{ sender: "system_error", content: "Failed" }],
+        "completed",
+        false,
+      ),
+    ).toEqual([]);
+  });
+});

--- a/lib/chat-request-state.ts
+++ b/lib/chat-request-state.ts
@@ -1,0 +1,51 @@
+export type RequestTerminalState =
+  | "open"
+  | "completed"
+  | "stopped"
+  | "failed";
+
+type RequestMessage = {
+  sender: string;
+};
+
+export function getRequestTerminalState(
+  messages: RequestMessage[],
+): RequestTerminalState {
+  if (messages.some((message) => message.sender === "parrot")) {
+    return "completed";
+  }
+  if (messages.some((message) => message.sender === "system_stopped")) {
+    return "stopped";
+  }
+  if (messages.some((message) => message.sender === "system_error")) {
+    return "failed";
+  }
+  return "open";
+}
+
+export function selectTerminalSafeMessages<T extends RequestMessage>(
+  pendingMessages: T[],
+  existingState: RequestTerminalState,
+  stopRequested: boolean,
+): T[] {
+  let selectedTerminalMessage = existingState !== "open";
+
+  return pendingMessages.filter((message) => {
+    const isCompletedMessage = message.sender === "parrot";
+    const isStoppedMessage = message.sender === "system_stopped";
+    const isFailureMessage = message.sender === "system_error";
+
+    if (!isCompletedMessage && !isStoppedMessage && !isFailureMessage) {
+      return true;
+    }
+    if (selectedTerminalMessage) {
+      return false;
+    }
+    if (stopRequested ? !isStoppedMessage : isStoppedMessage) {
+      return false;
+    }
+
+    selectedTerminalMessage = true;
+    return true;
+  });
+}

--- a/lib/chat-requests.test.ts
+++ b/lib/chat-requests.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateRetry } from "./chat-requests";
+
+describe("retry idempotency", () => {
+  it("allows retry only when the user request exists without a successful answer", () => {
+    expect(
+      evaluateRetry(
+        [
+          { sender: "user", requestId: "request-1" },
+          { sender: "tool_summary", requestId: "request-1" },
+          { sender: "system_error", requestId: "request-1" },
+        ],
+        "request-1",
+      ),
+    ).toBe("retryable");
+  });
+
+  it("rejects retry after a successful assistant response", () => {
+    expect(
+      evaluateRetry(
+        [
+          { sender: "user", requestId: "request-1" },
+          { sender: "parrot", requestId: "request-1" },
+        ],
+        "request-1",
+      ),
+    ).toBe("already_succeeded");
+  });
+
+  it("rejects a retry request without its original user message", () => {
+    expect(
+      evaluateRetry(
+        [{ sender: "system_error", requestId: "request-1" }],
+        "request-1",
+      ),
+    ).toBe("missing_user");
+  });
+});

--- a/lib/chat-requests.ts
+++ b/lib/chat-requests.ts
@@ -1,0 +1,23 @@
+type RequestMessage = {
+  sender: string;
+  requestId?: string | null;
+};
+
+export type RetryDecision = "retryable" | "already_succeeded" | "missing_user";
+
+export function evaluateRetry(
+  messages: RequestMessage[],
+  requestId: string,
+): RetryDecision {
+  const requestMessages = messages.filter((message) => message.requestId === requestId);
+
+  if (requestMessages.some((message) => message.sender === "parrot")) {
+    return "already_succeeded";
+  }
+
+  if (!requestMessages.some((message) => message.sender === "user")) {
+    return "missing_user";
+  }
+
+  return "retryable";
+}

--- a/lib/chat-title.ts
+++ b/lib/chat-title.ts
@@ -1,0 +1,24 @@
+export const MAX_CONVERSATION_TITLE_LENGTH = 72;
+
+export function deterministicConversationTitle(currentConversation: string) {
+  const mostRecentUserMessage =
+    currentConversation
+      .split("\n")
+      .reverse()
+      .find((line) => /^\s*user\s*:/i.test(line))
+      ?.replace(/^\s*user\s*:\s*/i, "") ?? currentConversation;
+  const normalized = mostRecentUserMessage
+    .replace(/[#>*_`[\]()]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!normalized) return "New Conversation";
+
+  const words = normalized.split(" ");
+  const shortTitle = words.slice(0, 9).join(" ");
+  const hasMore =
+    words.length > 9 || shortTitle.length > MAX_CONVERSATION_TITLE_LENGTH;
+  return `${shortTitle
+    .slice(0, MAX_CONVERSATION_TITLE_LENGTH - (hasMore ? 1 : 0))
+    .trim()}${hasMore ? "…" : ""}`;
+}

--- a/lib/chat-turns.test.ts
+++ b/lib/chat-turns.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  groupChatMessagesIntoTurns,
+  selectBranchPrefix,
+  type ChatMessageRecord,
+} from "./chat-turns";
+
+function message(
+  id: string,
+  sender: string,
+  content: string,
+  requestId?: string | null,
+): ChatMessageRecord {
+  return { id, sender, content, requestId };
+}
+
+describe("chat turn grouping", () => {
+  it("associates every request-ID artifact with the correct turn", () => {
+    const turns = groupChatMessagesIntoTurns([
+      message("u1", "user", "First", "request-1"),
+      message("s1", "tool_summary", "Source one", "request-1"),
+      message("a1", "parrot", "Answer one", "request-1"),
+      message("u2", "user", "Second", "request-2"),
+      message("e2", "system_error", "Failed", "request-2"),
+    ]);
+
+    expect(turns).toHaveLength(2);
+    expect(turns[0].user?.id).toBe("u1");
+    expect(turns[0].sources.map((source) => source.id)).toEqual(["s1"]);
+    expect(turns[0].assistant?.id).toBe("a1");
+    expect(turns[1].user?.id).toBe("u2");
+    expect(turns[1].failure?.id).toBe("e2");
+    expect(turns[1].assistant).toBeNull();
+  });
+
+  it("groups contiguous legacy sources with the assistant that follows", () => {
+    const turns = groupChatMessagesIntoTurns([
+      message("u1", "user", "Legacy question"),
+      message("g1", "gotQuestions", "Research"),
+      message("c1", "CCEL", "Classic source"),
+      message("a1", "parrot", "Legacy answer"),
+      message("u2", "user", "Next question"),
+      message("a2", "parrot", "Next answer"),
+    ]);
+
+    expect(turns).toHaveLength(2);
+    expect(turns[0].sources.map((source) => source.id)).toEqual(["g1", "c1"]);
+    expect(turns[0].assistant?.id).toBe("a1");
+    expect(turns[1].assistant?.id).toBe("a2");
+  });
+});
+
+describe("branch prefix selection", () => {
+  const transcript = [
+    message("u1", "user", "First", "r1"),
+    message("a1", "parrot", "First answer", "r1"),
+    message("u2", "user", "Second", "r2"),
+    message("a2", "parrot", "Second answer", "r2"),
+  ];
+
+  it("copies only messages before the selected user message", () => {
+    expect(selectBranchPrefix(transcript, "u2").map((row) => row.id)).toEqual([
+      "u1",
+      "a1",
+    ]);
+  });
+
+  it("rejects non-user and missing selections", () => {
+    expect(() => selectBranchPrefix(transcript, "a1")).toThrow();
+    expect(() => selectBranchPrefix(transcript, "missing")).toThrow();
+  });
+});

--- a/lib/chat-turns.ts
+++ b/lib/chat-turns.ts
@@ -1,0 +1,128 @@
+export type ChatMessageRecord = {
+  id: string;
+  sender: string;
+  content: string;
+  requestId?: string | null;
+  timestamp?: string | Date;
+  toolName?: string;
+};
+
+export type ChatTurn = {
+  key: string;
+  requestId: string | null;
+  user: ChatMessageRecord | null;
+  sources: ChatMessageRecord[];
+  assistant: ChatMessageRecord | null;
+  failure: ChatMessageRecord | null;
+  stopped: ChatMessageRecord | null;
+  firstMessageIndex: number;
+};
+
+function createTurn(key: string, requestId: string | null, firstMessageIndex: number): ChatTurn {
+  return {
+    key,
+    requestId,
+    user: null,
+    sources: [],
+    assistant: null,
+    failure: null,
+    stopped: null,
+    firstMessageIndex,
+  };
+}
+
+function addMessageToTurn(turn: ChatTurn, message: ChatMessageRecord) {
+  switch (message.sender) {
+    case "user":
+      turn.user ??= message;
+      break;
+    case "tool_summary":
+    case "gotQuestions":
+    case "CCEL":
+      turn.sources.push(message);
+      break;
+    case "parrot":
+      turn.assistant = message;
+      break;
+    case "calvin":
+      if (!turn.assistant) {
+        turn.assistant = message;
+      } else {
+        turn.sources.push({
+          ...message,
+          sender: "tool_summary",
+          toolName: message.toolName ?? "Calvin's Feedback",
+        });
+      }
+      break;
+    case "system_error":
+      turn.failure = message;
+      break;
+    case "system_stopped":
+      turn.stopped = message;
+      break;
+    default:
+      if (!turn.assistant) {
+        turn.assistant = message;
+      }
+      break;
+  }
+}
+
+/**
+ * Groups persisted and streaming rows into request/response turns.
+ *
+ * New rows use requestId for exact association. Legacy rows are grouped by
+ * contiguous user → tool summary → assistant/error order.
+ */
+export function groupChatMessagesIntoTurns(messages: ChatMessageRecord[]): ChatTurn[] {
+  const turns: ChatTurn[] = [];
+  const requestTurns = new Map<string, ChatTurn>();
+  let legacyTurn: ChatTurn | null = null;
+  let legacySequence = 0;
+
+  messages.forEach((message, index) => {
+    if (message.requestId) {
+      legacyTurn = null;
+      let turn = requestTurns.get(message.requestId);
+      if (!turn) {
+        turn = createTurn(`request:${message.requestId}`, message.requestId, index);
+        requestTurns.set(message.requestId, turn);
+        turns.push(turn);
+      }
+      addMessageToTurn(turn, message);
+      return;
+    }
+
+    const needsNewLegacyTurn =
+      !legacyTurn ||
+      message.sender === "user" ||
+      (message.sender === "parrot" && Boolean(legacyTurn.assistant)) ||
+      (message.sender === "tool_summary" &&
+        Boolean(legacyTurn.assistant || legacyTurn.failure || legacyTurn.stopped));
+
+    if (needsNewLegacyTurn) {
+      legacyTurn = createTurn(`legacy:${legacySequence++}`, null, index);
+      turns.push(legacyTurn);
+    }
+
+    addMessageToTurn(legacyTurn!, message);
+  });
+
+  return turns.sort((a, b) => a.firstMessageIndex - b.firstMessageIndex);
+}
+
+export function selectBranchPrefix(
+  messages: ChatMessageRecord[],
+  selectedUserMessageId: string,
+): ChatMessageRecord[] {
+  const selectedIndex = messages.findIndex(
+    (message) => message.id === selectedUserMessageId && message.sender === "user",
+  );
+
+  if (selectedIndex < 0) {
+    throw new Error("The selected user message was not found.");
+  }
+
+  return messages.slice(0, selectedIndex);
+}

--- a/lib/progressUtils.ts
+++ b/lib/progressUtils.ts
@@ -1,16 +1,18 @@
 // lib/progressUtils.ts
 
+type RequestEvent = { requestId?: string };
+
 type DataEvent =
-  | { type: "info" | "done" }
-  | { type: "error"; stage: string; message: string }
-  | { type: "progress"; title: string; content: string }
-  | { type: "tool_progress"; toolName: string; message: string }
-  | { type: "tool_summary"; toolName: string; content: string; raw?: unknown }
-  | { type: "parrot"; content: string }
-  | { type: "calvin"; content: string }
-  | { type: "gotQuestions"; content: string }
-  | { type: "CCEL"; content: string }
-  | { type: "conversationNameUpdated"; chatId: string; name: string };
+  | ({ type: "info" | "done" | "stopped" } & RequestEvent)
+  | ({ type: "error"; stage: string; message: string } & RequestEvent)
+  | ({ type: "progress"; title: string; content: string } & RequestEvent)
+  | ({ type: "tool_progress"; toolName: string; message: string } & RequestEvent)
+  | ({ type: "tool_summary"; toolName: string; content: string } & RequestEvent)
+  | ({ type: "parrot"; content: string } & RequestEvent)
+  | ({ type: "calvin"; content: string } & RequestEvent)
+  | ({ type: "gotQuestions"; content: string } & RequestEvent)
+  | ({ type: "CCEL"; content: string } & RequestEvent)
+  | ({ type: "conversationNameUpdated"; chatId: string; name: string } & RequestEvent);
 
 // Shared function for streaming progress messages.
 export function sendProgress(data: DataEvent, controller?: ReadableStreamDefaultController<Uint8Array>) {
@@ -27,7 +29,8 @@ export function sendProgress(data: DataEvent, controller?: ReadableStreamDefault
 export function sendError(
   error: Error | unknown,
   stage: string,
-  controller: ReadableStreamDefaultController<Uint8Array>
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  requestId?: string,
 ) {
   console.error(`Error during ${stage}:`, error);
   sendProgress(
@@ -35,6 +38,7 @@ export function sendError(
       type: "error",
       stage,
       message: "An error occurred, but continuing conversation...",
+      requestId,
     },
     controller
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calvinist-parrot",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calvinist-parrot",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
         "@google/genai": "^1.34.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calvinist-parrot",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "engines": {
     "node": "24.x"
@@ -22,7 +22,8 @@
     "db:reset": "prisma migrate reset",
     "db:seed": "prisma db seed",
     "db:studio": "prisma studio",
-    "db:generate": "prisma generate"
+    "db:generate": "prisma generate",
+    "db:worktree:setup": "node scripts/setup-worktree-database.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.73.0",

--- a/prisma/migrations/20260725000000_chat_message_request_id/migration.sql
+++ b/prisma/migrations/20260725000000_chat_message_request_id/migration.sql
@@ -1,0 +1,5 @@
+-- Associate every message artifact with the request that produced it.
+ALTER TABLE "chatMessage" ADD COLUMN "requestId" TEXT;
+
+CREATE INDEX "chatMessage_chatId_requestId_idx"
+ON "chatMessage"("chatId", "requestId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -231,10 +231,13 @@ model chatHistory {
 model chatMessage {
   id        String      @id @default(cuid())
   chatId    String
+  requestId String?
   sender    String
   content   String
   timestamp DateTime    @default(now())
   chat      chatHistory @relation("ChatMessages", fields: [chatId], references: [id])
+
+  @@index([chatId, requestId])
 }
 
 model parrotDevotionals {

--- a/scripts/setup-worktree-database.mjs
+++ b/scripts/setup-worktree-database.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  copyFile,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const POSTGRES_USER = "calvinist_parrot";
+const POSTGRES_HOST = "localhost";
+const POSTGRES_PORT = 54322;
+const GENERATED_ENV_MARKER =
+  "# Generated for this Codex worktree by scripts/setup-worktree-database.mjs.";
+
+function databaseUrl(databaseName) {
+  return `postgresql://${POSTGRES_USER}:${POSTGRES_USER}@${POSTGRES_HOST}:${POSTGRES_PORT}/${databaseName}?schema=public`;
+}
+
+export function createWorktreeDatabaseConfig(worktreePath) {
+  const resolvedPath = path.resolve(worktreePath);
+  const worktreeId = createHash("sha256")
+    .update(resolvedPath)
+    .digest("hex")
+    .slice(0, 12);
+
+  const databaseNames = {
+    development: `calvinist_parrot_dev_${worktreeId}`,
+    shadow: `calvinist_parrot_shadow_${worktreeId}`,
+    test: `calvinist_parrot_test_${worktreeId}`,
+  };
+
+  return {
+    worktreeId,
+    databaseNames,
+    urls: {
+      DATABASE_URL: databaseUrl(databaseNames.development),
+      SHADOW_DATABASE_URL: databaseUrl(databaseNames.shadow),
+      TEST_DATABASE_URL: databaseUrl(databaseNames.test),
+    },
+  };
+}
+
+export function renderWorktreeEnv(template, urls) {
+  const remainingKeys = new Set(Object.keys(urls));
+  const renderedLines = template.split(/\r?\n/).map((line) => {
+    const match = /^([A-Z][A-Z0-9_]*)=/.exec(line);
+    const key = match?.[1];
+
+    if (!key || !remainingKeys.has(key)) {
+      return line;
+    }
+
+    remainingKeys.delete(key);
+    return `${key}=${JSON.stringify(urls[key])}`;
+  });
+
+  if (remainingKeys.size > 0) {
+    throw new Error(
+      `.env.template is missing required database variables: ${[
+        ...remainingKeys,
+      ].join(", ")}`,
+    );
+  }
+
+  return `${GENERATED_ENV_MARKER}\n${renderedLines.join("\n")}`;
+}
+
+export function assertCredentialOverlayIsSafe(contents, sourceName) {
+  const databaseOverride =
+    /^\s*(?:export\s+)?(DATABASE_URL|SHADOW_DATABASE_URL|TEST_DATABASE_URL)\s*=/m.exec(
+      contents,
+    );
+
+  if (databaseOverride) {
+    throw new Error(
+      `${sourceName} must not define ${databaseOverride[1]}; Codex worktree database URLs are generated automatically.`,
+    );
+  }
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    input: options.input,
+    stdio: options.input
+      ? ["pipe", "inherit", "inherit"]
+      : ["ignore", "inherit", "inherit"],
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} exited with status ${result.status}`,
+    );
+  }
+}
+
+function ensureDatabase(worktreePath, databaseName) {
+  const createDatabaseSql = `
+SELECT pg_advisory_lock(hashtext(:'db_name'));
+
+SELECT format(
+  'CREATE DATABASE %I OWNER ${POSTGRES_USER}',
+  :'db_name'
+)
+WHERE NOT EXISTS (
+  SELECT 1 FROM pg_database WHERE datname = :'db_name'
+)
+\\gexec
+
+SELECT pg_advisory_unlock(hashtext(:'db_name'));
+`;
+
+  run(
+    "docker",
+    [
+      "compose",
+      "exec",
+      "-T",
+      "postgres",
+      "psql",
+      "--no-psqlrc",
+      `--username=${POSTGRES_USER}`,
+      "--dbname=postgres",
+      "--set=ON_ERROR_STOP=1",
+      `--set=db_name=${databaseName}`,
+    ],
+    { cwd: worktreePath, input: createDatabaseSql },
+  );
+
+  run(
+    "docker",
+    [
+      "compose",
+      "exec",
+      "-T",
+      "postgres",
+      "psql",
+      "--no-psqlrc",
+      `--username=${POSTGRES_USER}`,
+      `--dbname=${databaseName}`,
+      "--set=ON_ERROR_STOP=1",
+      "--command=CREATE EXTENSION IF NOT EXISTS vector;",
+    ],
+    { cwd: worktreePath },
+  );
+}
+
+async function writeGeneratedEnv(worktreePath, contents) {
+  const envPath = path.join(worktreePath, ".env");
+  const temporaryPath = path.join(
+    worktreePath,
+    `.env.worktree-${process.pid}.tmp`,
+  );
+
+  try {
+    await writeFile(temporaryPath, contents, { mode: 0o600 });
+    await rename(temporaryPath, envPath);
+    await chmod(envPath, 0o600);
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
+}
+
+async function copyWorktreeCredentials(worktreePath) {
+  const sourcePath = path.join(worktreePath, ".env.worktree.local");
+  const destinationPath = path.join(worktreePath, ".env.local");
+
+  try {
+    const credentials = await readFile(sourcePath, "utf8");
+    assertCredentialOverlayIsSafe(credentials, ".env.worktree.local");
+    await copyFile(sourcePath, destinationPath);
+    await chmod(destinationPath, 0o600);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      try {
+        const existingCredentials = await readFile(destinationPath, "utf8");
+        assertCredentialOverlayIsSafe(existingCredentials, ".env.local");
+      } catch (destinationError) {
+        if (destinationError?.code !== "ENOENT") {
+          throw destinationError;
+        }
+      }
+      return false;
+    }
+    throw error;
+  }
+}
+
+export async function setupWorktreeDatabase(worktreePath) {
+  const resolvedPath = path.resolve(worktreePath);
+  const templatePath = path.join(resolvedPath, ".env.template");
+  const config = createWorktreeDatabaseConfig(resolvedPath);
+
+  for (const databaseName of Object.values(config.databaseNames)) {
+    ensureDatabase(resolvedPath, databaseName);
+  }
+
+  const template = await readFile(templatePath, "utf8");
+  const envContents = renderWorktreeEnv(template, config.urls);
+  await writeGeneratedEnv(resolvedPath, envContents);
+  const copiedCredentials = await copyWorktreeCredentials(resolvedPath);
+
+  console.log(`Provisioned isolated databases for worktree ${config.worktreeId}:`);
+  console.log(`- development: ${config.databaseNames.development}`);
+  console.log(`- shadow: ${config.databaseNames.shadow}`);
+  console.log(`- test: ${config.databaseNames.test}`);
+  console.log(
+    copiedCredentials
+      ? "Copied .env.worktree.local to .env.local."
+      : "No .env.worktree.local was present; continuing without credential overrides.",
+  );
+
+  return config;
+}
+
+async function main() {
+  const worktreePath = process.env.CODEX_WORKTREE_PATH;
+  if (!worktreePath) {
+    throw new Error(
+      "CODEX_WORKTREE_PATH is required. Run this through the Codex worktree local-environment setup.",
+    );
+  }
+
+  await setupWorktreeDatabase(worktreePath);
+}
+
+const executedModuleUrl = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : "";
+
+if (import.meta.url === executedModuleUrl) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/setup-worktree-database.test.ts
+++ b/scripts/setup-worktree-database.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertCredentialOverlayIsSafe,
+  createWorktreeDatabaseConfig,
+  renderWorktreeEnv,
+} from "./setup-worktree-database.mjs";
+
+describe("worktree database setup", () => {
+  it("creates stable, isolated database names for each worktree path", () => {
+    const first = createWorktreeDatabaseConfig("/tmp/codex/worktrees/first");
+    const firstAgain = createWorktreeDatabaseConfig(
+      "/tmp/codex/worktrees/first",
+    );
+    const second = createWorktreeDatabaseConfig("/tmp/codex/worktrees/second");
+
+    expect(first).toEqual(firstAgain);
+    expect(first.worktreeId).toMatch(/^[a-f0-9]{12}$/);
+    expect(first.databaseNames.development).not.toBe(
+      second.databaseNames.development,
+    );
+    expect(first.urls.DATABASE_URL).toContain(
+      `/${first.databaseNames.development}?schema=public`,
+    );
+    expect(first.urls.SHADOW_DATABASE_URL).toContain(
+      `/${first.databaseNames.shadow}?schema=public`,
+    );
+    expect(first.urls.TEST_DATABASE_URL).toContain(
+      `/${first.databaseNames.test}?schema=public`,
+    );
+  });
+
+  it("replaces the template database URLs without duplicating variables", () => {
+    const config = createWorktreeDatabaseConfig(
+      "/tmp/codex/worktrees/example",
+    );
+    const template = [
+      "OPENAI_API_KEY=",
+      'DATABASE_URL="postgresql://old/dev"',
+      'SHADOW_DATABASE_URL="postgresql://old/shadow"',
+      'TEST_DATABASE_URL="postgresql://old/test"',
+      "",
+    ].join("\n");
+
+    const rendered = renderWorktreeEnv(template, config.urls);
+
+    expect(rendered.match(/^DATABASE_URL=/gm)).toHaveLength(1);
+    expect(rendered.match(/^SHADOW_DATABASE_URL=/gm)).toHaveLength(1);
+    expect(rendered.match(/^TEST_DATABASE_URL=/gm)).toHaveLength(1);
+    expect(rendered).toContain(config.urls.DATABASE_URL);
+    expect(rendered).toContain(config.urls.SHADOW_DATABASE_URL);
+    expect(rendered).toContain(config.urls.TEST_DATABASE_URL);
+    expect(rendered).not.toContain("postgresql://old");
+  });
+
+  it("fails when the template no longer contains every database variable", () => {
+    const config = createWorktreeDatabaseConfig(
+      "/tmp/codex/worktrees/example",
+    );
+
+    expect(() =>
+      renderWorktreeEnv("DATABASE_URL=postgresql://old/dev\n", config.urls),
+    ).toThrow("SHADOW_DATABASE_URL, TEST_DATABASE_URL");
+  });
+
+  it("rejects database URLs in the credential-only overlay", () => {
+    expect(() =>
+      assertCredentialOverlayIsSafe(
+        "OPENAI_API_KEY=local\nDATABASE_URL=postgresql://production\n",
+        ".env.worktree.local",
+      ),
+    ).toThrow(
+      ".env.worktree.local must not define DATABASE_URL; Codex worktree database URLs are generated automatically.",
+    );
+
+    expect(() =>
+      assertCredentialOverlayIsSafe(
+        "# DATABASE_URL is generated\nOPENAI_API_KEY=local\n",
+        ".env.worktree.local",
+      ),
+    ).not.toThrow();
+  });
+});

--- a/utils/buildParrotSystemPrompt.ts
+++ b/utils/buildParrotSystemPrompt.ts
@@ -2,6 +2,7 @@
 // Centralized builder for the Parrot system prompt with denomination mapping and pastoral context injection
 
 import * as prompts from "@/lib/prompts/core";
+import { resolveEffectiveDenomination } from "@/lib/chat-context";
 
 export interface PastoralUserProfile {
   denomination: string | null;
@@ -150,7 +151,10 @@ export function buildParrotSystemPrompt(params: {
 
   const pastoralContext = buildPastoralContext(userProfile, effectiveUserId);
 
-  const effectiveDenomination = userProfile?.denomination || denominationFallback || "reformed-baptist";
+  const effectiveDenomination = resolveEffectiveDenomination(
+    userProfile?.denomination,
+    denominationFallback,
+  );
   const secondaryPromptText = mapDenominationPrompt(effectiveDenomination);
   const coreSysPromptWithDenomination = prompts.CORE_SYS_PROMPT.replace("{denomination}", secondaryPromptText);
   let newParrotSysPrompt = prompts.PARROT_SYS_PROMPT_MAIN.replace("{CORE}", coreSysPromptWithDenomination);

--- a/utils/generateConversationName.test.ts
+++ b/utils/generateConversationName.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { deterministicConversationTitle } from "../lib/chat-title";
+
+describe("deterministic conversation title fallback", () => {
+  it("uses the most recent user message and stays concise", () => {
+    const title = deterministicConversationTitle(
+      "user: What is justification?\nparrot: An answer\nuser: How does adoption relate to union with Christ and sanctification over time?",
+    );
+
+    expect(title).toBe(
+      "How does adoption relate to union with Christ and…",
+    );
+    expect(title.length).toBeLessThanOrEqual(72);
+  });
+
+  it("returns a stable fallback for empty content", () => {
+    expect(deterministicConversationTitle("")).toBe("New Conversation");
+  });
+});

--- a/utils/generateConversationName.ts
+++ b/utils/generateConversationName.ts
@@ -6,8 +6,22 @@ import {
     n_shot_examples,
   } from '@/lib/prompts/parrot-qa';
 import type { ChatMessage } from '@/lib/parrot-ai';
+import {
+  deterministicConversationTitle,
+  MAX_CONVERSATION_TITLE_LENGTH,
+} from '@/lib/chat-title';
 
-// Helper: generate conversation name
+const MAX_NAME_ATTEMPTS = 2;
+
+function normalizeGeneratedTitle(value: string) {
+  return value
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_CONVERSATION_TITLE_LENGTH);
+}
+
+// Helper: generate a conversation name with bounded retries and a deterministic fallback.
 export async function generateConversationName(currentConversation: string): Promise<string> {
   const promptCreateName = `I have this conversation:
 
@@ -31,19 +45,25 @@ What would you like to name this conversation? It can be a short name to remembe
     },
   };
 
-  try {
-    const result = await parrotAI.generateStructured<{ name: string }>({
-      messages: [
-        { role: "system", content: 'You are a helpful assistant that can create short names for conversations.' },
-        { role: "user", content: promptCreateName },
-      ],
-      schema: conversationNameSchema,
-    });
-
-    return result.data.name;
-  } catch {
-    return await generateConversationName(currentConversation);
+  for (let attempt = 0; attempt < MAX_NAME_ATTEMPTS; attempt += 1) {
+    try {
+      const result = await parrotAI.generateStructured<{ name: string }>({
+        messages: [
+          { role: "system", content: 'You are a helpful assistant that can create short names for conversations.' },
+          { role: "user", content: promptCreateName },
+        ],
+        schema: conversationNameSchema,
+      });
+      const title = normalizeGeneratedTitle(result.data.name);
+      if (title) return title;
+    } catch (error) {
+      if (attempt === MAX_NAME_ATTEMPTS - 1) {
+        console.error("Conversation naming failed after bounded retries:", error);
+      }
+    }
   }
+
+  return deterministicConversationTitle(currentConversation);
 }
 
 // Build categorization messages


### PR DESCRIPTION
## Summary

- rebuild the landing and active-chat experiences around shared shell, composer, turn, action, source/process, shortcut, and suggested-question components
- add responsive auto-growing composers, clearer light-mode surface separation, bottom-anchored mobile shortcuts, contextual denomination guidance, and viewport-safe journal entry composition
- add rich Formatted for Word, Markdown, plain-text, and manual-selection copy with semantic formatting and absolute internal URLs
- add non-destructive message editing that branches from the transcript prefix, request-scoped streaming artifacts, improved chat list lifecycle actions, and resilient conversation titles
- update the color mapping, design system, and internationalization plan to document the accepted responsive, accessibility, clipboard, and RTL behavior

## Why

The previous chat routes combined transcript rendering, composer behavior, navigation, streaming state, and message actions in large route components. Fixed-size and route-specific UI also caused inconsistent responsive behavior, weak light-mode separation, destructive-feeling context controls, and clipped journal actions on smaller phones.

This redesign moves those responsibilities into focused shared components and gives message artifacts a request ID so streamed progress, sources, failures, and answers remain associated with the request that produced them.

## Database migration

Adds nullable `chatMessage.requestId` plus an index on `(chatId, requestId)`. Run the included Prisma migration during deployment.

## Validation

- `npm test` — 8 files, 24 tests passed
- `npm run check` — ESLint and TypeScript passed
- `npx prisma validate` — schema valid
- `npm run build` — production build passed
- `git diff --check` — passed
- browser-verified responsive home/chat behavior at 389px and 390px
- browser-verified journal composer at 375×667 and 430×932, including long content, visible actions, Escape dismissal, and no horizontal overflow
- checked light and dark theme treatments; application console remained clean