### PR TITLE
Make church evaluation multilingual and timeout resilient

### DIFF
--- a/app/api/churches/route.test.ts
+++ b/app/api/churches/route.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ChurchEvaluationRaw, CoreDoctrineMap } from "@/types/church";
+import { ChurchEvaluationTimeoutError } from "@/lib/church-evaluation/runtime";
+
+const mocks = vi.hoisted(() => {
+  const transactionClient = {
+    church: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+    churchAddress: {
+      deleteMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    churchServiceTime: {
+      deleteMany: vi.fn(),
+      create: vi.fn(),
+    },
+    churchEvaluation: {
+      create: vi.fn(),
+    },
+  };
+
+  return {
+    after: vi.fn(),
+    afterCallbacks: [] as Array<() => Promise<void>>,
+    extractChurchEvaluation: vi.fn(),
+    geocodeAddress: vi.fn(),
+    postProcessEvaluation: vi.fn(),
+    mapChurchToDetail: vi.fn(),
+    transactionClient,
+    prisma: {
+      church: {
+        findUnique: vi.fn(),
+      },
+      $transaction: vi.fn(),
+    },
+  };
+});
+
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>();
+  return {
+    ...actual,
+    after: mocks.after,
+  };
+});
+
+vi.mock("@/lib/prisma", () => ({
+  default: mocks.prisma,
+}));
+
+vi.mock("@/lib/churchMapper", () => ({
+  mapChurchToDetail: mocks.mapChurchToDetail,
+  mapChurchToListItem: vi.fn(),
+}));
+
+vi.mock("@/utils/churchEvaluation", () => ({
+  extractChurchEvaluation: mocks.extractChurchEvaluation,
+  geocodeAddress: mocks.geocodeAddress,
+  postProcessEvaluation: mocks.postProcessEvaluation,
+  toCoreDoctrineStatusEnum: (value: string) => value.toUpperCase(),
+  toEvaluationStatusEnum: (value: string) => value.toUpperCase(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getAuthenticatedUser: vi.fn(),
+}));
+
+vi.mock("@/lib/admin", () => ({
+  isServerAdminUser: vi.fn(() => true),
+}));
+
+import { maxDuration, POST } from "./route";
+
+const normalizedCore = {
+  trinity: "true",
+  gospel: "true",
+  justification_by_faith: "true",
+  christ_deity_humanity: "true",
+  scripture_authority: "true",
+  incarnation_virgin_birth: "true",
+  atonement_necessary_sufficient: "true",
+  resurrection_of_jesus: "true",
+  return_and_judgment: "true",
+  character_of_god: "true",
+} satisfies CoreDoctrineMap;
+
+const rawEvaluation: ChurchEvaluationRaw = {
+  metadata: {
+    model: "gemini-3.6-flash",
+    prompt_version: "2026-07-28",
+    policy_version: "2026-07-26",
+    evaluated_at: "2026-07-28T00:00:00.000Z",
+    source_pages: [{
+      requested_url: "https://example.church/",
+      resolved_url: "https://example.church/",
+      content_sha256: "abc123",
+    }],
+  },
+  church: {
+    name: "Example Church",
+    website: "https://example.church/",
+    addresses: [{
+      street_1: "1 Church Way",
+      street_2: null,
+      city: "Austin",
+      state: "TX",
+      post_code: "78701",
+      source_url: "https://example.church/visit",
+    }],
+    contacts: { phone: null, email: null },
+    service_times: ["Sunday 10:00"],
+    best_pages_for: {
+      beliefs: "https://example.church/beliefs",
+      confession: null,
+      about: "https://example.church/about",
+      leadership: "https://example.church/leadership",
+    },
+    denomination: {
+      label: "Reformed Baptist",
+      confidence: 0.9,
+      signals: ["confession"],
+    },
+    confession: {
+      adopted: true,
+      name: "Second London Baptist Confession (1689)",
+      source_url: "https://example.church/beliefs",
+    },
+    core_doctrines: normalizedCore,
+    secondary: {
+      baptism: null,
+      governance: null,
+      lords_supper: null,
+      gifts: null,
+      sanctification: null,
+      continuity: null,
+      security: null,
+      atonement_model: null,
+    },
+    tertiary: {
+      eschatology: null,
+      worship_style: null,
+      counseling: null,
+      creation: null,
+      christian_liberty: null,
+      discipline: null,
+      parachurch: null,
+      marriage_roles: null,
+    },
+    badges: ["📜 Reformed"],
+    notes: [],
+  },
+};
+
+const persistedChurch = {
+  id: "church-1",
+  addresses: [{
+    id: "address-1",
+    street1: "1 Church Way",
+    city: "Austin",
+    state: "TX",
+    postCode: "78701",
+  }],
+  serviceTimes: [],
+  evaluations: [],
+};
+
+describe("POST /api/churches", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.afterCallbacks.length = 0;
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.after.mockImplementation((callback: () => Promise<void>) => {
+      mocks.afterCallbacks.push(callback);
+    });
+    mocks.prisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mocks.transactionClient) => unknown) =>
+        callback(mocks.transactionClient),
+    );
+    mocks.prisma.church.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(persistedChurch);
+    mocks.transactionClient.church.findUnique.mockResolvedValue(null);
+    mocks.transactionClient.church.create.mockResolvedValue({ id: "church-1" });
+    mocks.extractChurchEvaluation.mockResolvedValue(rawEvaluation);
+    mocks.postProcessEvaluation.mockReturnValue({
+      normalizedCore,
+      badges: ["📜 Reformed"],
+      coverageRatio: 1,
+      coreOnSiteCount: 10,
+      status: "recommended",
+    });
+    mocks.mapChurchToDetail.mockReturnValue({
+      id: "church-1",
+      name: "Example Church",
+    });
+    mocks.geocodeAddress.mockResolvedValue({
+      latitude: 30.2672,
+      longitude: -97.7431,
+    });
+  });
+
+  it("persists and returns ChurchDetail before after() geocoding runs", async () => {
+    const response = await POST(new Request("http://localhost/api/churches", {
+      method: "POST",
+      body: JSON.stringify({ website: "https://example.church" }),
+      headers: { "content-type": "application/json" },
+    }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: "church-1",
+      name: "Example Church",
+    });
+    expect(mocks.transactionClient.churchEvaluation.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        churchId: "church-1",
+        rawEvaluation: expect.objectContaining({
+          metadata: expect.objectContaining({
+            model: "gemini-3.6-flash",
+            prompt_version: "2026-07-28",
+          }),
+        }),
+      }),
+    });
+    expect(mocks.after).toHaveBeenCalledTimes(1);
+    expect(mocks.geocodeAddress).not.toHaveBeenCalled();
+
+    await mocks.afterCallbacks[0]();
+
+    expect(mocks.geocodeAddress).toHaveBeenCalledTimes(1);
+    expect(mocks.transactionClient.churchAddress.update).toHaveBeenCalledWith({
+      where: { id: "address-1" },
+      data: {
+        latitude: 30.2672,
+        longitude: -97.7431,
+      },
+    });
+  });
+
+  it("returns a controlled timeout before the platform ceiling", async () => {
+    mocks.extractChurchEvaluation.mockRejectedValue(
+      new ChurchEvaluationTimeoutError("gemini_core_doctrines", 55_000),
+    );
+
+    const response = await POST(new Request("http://localhost/api/churches", {
+      method: "POST",
+      body: JSON.stringify({ website: "https://example.church" }),
+      headers: { "content-type": "application/json" },
+    }));
+
+    expect(response.status).toBe(504);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        "Church evaluation timed out while waiting for an upstream service. Please try again.",
+      code: "CHURCH_EVALUATION_TIMEOUT",
+      stage: "gemini_core_doctrines",
+    });
+    expect(mocks.after).not.toHaveBeenCalled();
+  });
+
+  it("configures a five-minute route duration", () => {
+    expect(maxDuration).toBe(300);
+  });
+});

--- a/app/api/churches/route.ts
+++ b/app/api/churches/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { after, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 
 import prisma from "@/lib/prisma";
@@ -14,8 +14,18 @@ import {
 import { CORE_DOCTRINE_KEYS } from "@/lib/schemas/church-finder";
 import { isServerAdminUser } from "@/lib/admin";
 import type { ChurchEvaluationRaw } from "@/types/church";
+import {
+  ChurchEvaluationTimeoutError,
+  ChurchEvaluationUpstreamError,
+  logEvaluationStage,
+  measureEvaluationStage,
+  runEvaluationStage,
+} from "@/lib/church-evaluation/runtime";
 
 const DEFAULT_PAGE_SIZE = 10;
+const BACKGROUND_GEOCODING_BUDGET_MS = 20_000;
+
+export const maxDuration = 300;
 
 function parseBooleanParam(value: string | null): boolean | null {
   if (value === null) return null;
@@ -132,6 +142,60 @@ function buildEvaluationData(
     ),
     coreCharacterOfGod: toCoreDoctrineStatusEnum(processed.normalizedCore.character_of_god),
   };
+}
+
+type PersistedAddressForGeocoding = {
+  id: string;
+  street1: string | null;
+  city: string | null;
+  state: string | null;
+  postCode: string | null;
+};
+
+function scheduleAddressGeocoding(
+  persistedAddresses: PersistedAddressForGeocoding[],
+): void {
+  if (persistedAddresses.length === 0) return;
+
+  after(async () => {
+    try {
+      await runEvaluationStage({
+        stage: "background_geocoding",
+        deadlineAt: Date.now() + BACKGROUND_GEOCODING_BUDGET_MS,
+        maxDurationMs: BACKGROUND_GEOCODING_BUDGET_MS,
+        operation: async (signal) => {
+          const geocodedAddresses = await Promise.all(
+            persistedAddresses.map(async (address) => ({
+              id: address.id,
+              coords: await geocodeAddress({
+                street1: address.street1,
+                city: address.city,
+                state: address.state,
+                postCode: address.postCode,
+              }, signal),
+            })),
+          );
+
+          await prisma.$transaction(async (tx) => {
+            for (const entry of geocodedAddresses) {
+              await tx.churchAddress.update({
+                where: { id: entry.id },
+                data: {
+                  latitude: entry.coords.latitude,
+                  longitude: entry.coords.longitude,
+                },
+              });
+            }
+          });
+        },
+      });
+    } catch (error) {
+      console.error("church_geocoding_background_failed", {
+        error_name: error instanceof Error ? error.name : "UnknownError",
+        address_count: persistedAddresses.length,
+      });
+    }
+  });
 }
 
 export async function GET(request: Request) {
@@ -303,9 +367,17 @@ export async function POST(request: Request) {
     }
   }
 
+  const evaluationStartedAt = Date.now();
+  let sourcePageCount = 0;
+
   try {
     const rawEvaluation: ChurchEvaluationRaw = await extractChurchEvaluation(websiteUrl);
-    const processed = postProcessEvaluation(rawEvaluation);
+    sourcePageCount = rawEvaluation.metadata?.source_pages.length ?? 0;
+    const processed = await measureEvaluationStage({
+      stage: "post_processing",
+      operation: () => postProcessEvaluation(rawEvaluation),
+      dimensions: { sourcePageCount },
+    });
 
     const churchData = rawEvaluation.church;
     const fallbackName = new URL(websiteUrl).hostname.replace(/^www\./, "");
@@ -337,129 +409,147 @@ export async function POST(request: Request) {
       bestLeadershipUrl: churchData.best_pages_for?.leadership ?? null,
     };
 
-    const { churchId } = await prisma.$transaction(async (tx) => {
-      const existingChurch = await tx.church.findUnique({
-        where: { website: websiteUrl },
-        select: { id: true },
-      });
+    const persisted = await measureEvaluationStage({
+      stage: "persistence",
+      dimensions: { sourcePageCount },
+      operation: async () => {
+        const { churchId } = await prisma.$transaction(async (tx) => {
+          const existingChurch = await tx.church.findUnique({
+            where: { website: websiteUrl },
+            select: { id: true },
+          });
 
-      let persistedChurchId: string;
+          let persistedChurchId: string;
 
-      if (existingChurch) {
-        persistedChurchId = existingChurch.id;
-        await tx.church.update({ where: { id: persistedChurchId }, data: baseData });
-        await tx.churchAddress.deleteMany({ where: { churchId: persistedChurchId } });
-        await tx.churchServiceTime.deleteMany({ where: { churchId: persistedChurchId } });
-      } else {
-        const createdChurch = await tx.church.create({ data: baseData });
-        persistedChurchId = createdChurch.id;
-      }
+          if (existingChurch) {
+            persistedChurchId = existingChurch.id;
+            await tx.church.update({
+              where: { id: persistedChurchId },
+              data: baseData,
+            });
+            await tx.churchAddress.deleteMany({
+              where: { churchId: persistedChurchId },
+            });
+            await tx.churchServiceTime.deleteMany({
+              where: { churchId: persistedChurchId },
+            });
+          } else {
+            const createdChurch = await tx.church.create({ data: baseData });
+            persistedChurchId = createdChurch.id;
+          }
 
-      for (const [index, address] of addresses.entries()) {
-        await tx.churchAddress.create({
-          data: {
-            churchId: persistedChurchId,
-            street1: address.street_1 ?? null,
-            street2: address.street_2 ?? null,
-            city: address.city ?? null,
-            state: address.state ?? null,
-            postCode: address.post_code ?? null,
-            latitude: null,
-            longitude: null,
-            sourceUrl: address.source_url ?? null,
-            isPrimary: index === 0,
-          },
-        });
-      }
-
-      for (const label of serviceTimes) {
-        await tx.churchServiceTime.create({
-          data: {
-            churchId: persistedChurchId,
-            label,
-          },
-        });
-      }
-
-      await tx.churchEvaluation.create({
-        data: {
-          churchId: persistedChurchId,
-          ...evaluationData,
-        },
-      });
-
-      return { churchId: persistedChurchId };
-    });
-
-    const persisted = await prisma.church.findUnique({
-      where: { id: churchId },
-      include: {
-        addresses: { orderBy: [{ isPrimary: "desc" }, { createdAt: "asc" }] },
-        serviceTimes: { orderBy: { createdAt: "asc" } },
-        evaluations: { orderBy: { createdAt: "desc" }, take: 1 },
-      },
-    });
-
-    if (!persisted) {
-      return NextResponse.json({ error: "Unable to persist church" }, { status: 500 });
-    }
-
-    const response = NextResponse.json(mapChurchToDetail(persisted));
-
-    // ============================================================================
-    // Background Job: Geocode + Update Coordinates (Fire-and-Forget)
-    // ============================================================================
-    const persistedAddresses = persisted.addresses;
-
-    void (async () => {
-      try {
-        console.log(`[Background] Starting geocoding for ${websiteUrl}`);
-
-        const geocodedAddresses = await Promise.all(
-          addresses.map((address, index) =>
-            geocodeAddress({
-              street1: address.street_1,
-              city: address.city,
-              state: address.state,
-              postCode: address.post_code,
-            }).then((coords) => ({ index, coords }))
-          )
-        );
-
-        console.log(`[Background] Geocoding complete, updating coordinates...`);
-
-        await prisma.$transaction(async (tx) => {
-          for (const entry of geocodedAddresses) {
-            const targetAddress = persistedAddresses[entry.index];
-            if (!targetAddress) {
-              continue;
-            }
-
-            await tx.churchAddress.update({
-              where: { id: targetAddress.id },
+          for (const [index, address] of addresses.entries()) {
+            await tx.churchAddress.create({
               data: {
-                latitude: entry.coords.latitude,
-                longitude: entry.coords.longitude,
+                churchId: persistedChurchId,
+                street1: address.street_1 ?? null,
+                street2: address.street_2 ?? null,
+                city: address.city ?? null,
+                state: address.state ?? null,
+                postCode: address.post_code ?? null,
+                latitude: null,
+                longitude: null,
+                sourceUrl: address.source_url ?? null,
+                isPrimary: index === 0,
               },
             });
           }
+
+          for (const label of serviceTimes) {
+            await tx.churchServiceTime.create({
+              data: {
+                churchId: persistedChurchId,
+                label,
+              },
+            });
+          }
+
+          await tx.churchEvaluation.create({
+            data: {
+              churchId: persistedChurchId,
+              ...evaluationData,
+            },
+          });
+
+          return { churchId: persistedChurchId };
         });
 
-        console.log(`[Background] Coordinate update complete for ${websiteUrl}`);
-      } catch (error) {
-        console.error(`[Background] Failed to update coordinates for ${websiteUrl}:`, error);
-        // Background job failure doesn't affect user experience
-        // Could implement retry logic or logging service here
-      }
-    })();
+        const savedChurch = await prisma.church.findUnique({
+          where: { id: churchId },
+          include: {
+            addresses: {
+              orderBy: [{ isPrimary: "desc" }, { createdAt: "asc" }],
+            },
+            serviceTimes: { orderBy: { createdAt: "asc" } },
+            evaluations: {
+              orderBy: { createdAt: "desc" },
+              take: 1,
+            },
+          },
+        });
 
-    return response;
+        if (!savedChurch) {
+          throw new Error("Unable to persist church");
+        }
+
+        return savedChurch;
+      },
+    });
+
+    scheduleAddressGeocoding(persisted.addresses);
+    logEvaluationStage({
+      stage: "total",
+      status: "success",
+      startedAt: evaluationStartedAt,
+      dimensions: { sourcePageCount },
+    });
+    return NextResponse.json(mapChurchToDetail(persisted));
   } catch (error) {
-    console.error("Failed to evaluate church", error);
+    logEvaluationStage({
+      stage: "total",
+      status: error instanceof ChurchEvaluationTimeoutError
+        ? "timeout"
+        : "error",
+      startedAt: evaluationStartedAt,
+      dimensions: { sourcePageCount },
+      error,
+    });
+    console.error("church_evaluation_request_failed", {
+      error_name: error instanceof Error ? error.name : "UnknownError",
+      error_code: error instanceof ChurchEvaluationTimeoutError ||
+          error instanceof ChurchEvaluationUpstreamError
+        ? error.code
+        : undefined,
+      stage: error instanceof ChurchEvaluationTimeoutError ||
+          error instanceof ChurchEvaluationUpstreamError
+        ? error.stage
+        : undefined,
+    });
 
     const errorMessage = error instanceof Error ? error.message : "Unable to evaluate church at this time";
 
-    // Provide more specific error messages
+    if (error instanceof ChurchEvaluationTimeoutError) {
+      return NextResponse.json(
+        {
+          error: "Church evaluation timed out while waiting for an upstream service. Please try again.",
+          code: error.code,
+          stage: error.stage,
+        },
+        { status: 504 },
+      );
+    }
+
+    if (error instanceof ChurchEvaluationUpstreamError) {
+      return NextResponse.json(
+        {
+          error: "An upstream service could not complete the church evaluation. Please try again.",
+          code: error.code,
+          stage: error.stage,
+        },
+        { status: 502 },
+      );
+    }
+
     if (errorMessage.includes("Unable to gather website content")) {
       return NextResponse.json(
         {
@@ -469,11 +559,10 @@ export async function POST(request: Request) {
       );
     }
 
-    if (errorMessage.includes("TAVILY_API_KEY")) {
-      return NextResponse.json({ error: "Service configuration error" }, { status: 500 });
-    }
-
-    if (errorMessage.includes("OPENAI_API_KEY")) {
+    if (
+      errorMessage.includes("TAVILY_API_KEY") ||
+      errorMessage.includes("GEMINI_API_KEY")
+    ) {
       return NextResponse.json({ error: "Service configuration error" }, { status: 500 });
     }
 

--- a/lib/church-evaluation/crawl.test.ts
+++ b/lib/church-evaluation/crawl.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
+  crawlChurchSite,
   dropAnchorDupes,
   mergeExtractedPage,
   toChurchContentBlocks,
@@ -48,5 +49,47 @@ describe("church source preparation", () => {
 
     expect(result.results).toHaveLength(1);
     expect(result.results?.[0].url).toBe("https://example.church/beliefs");
+  });
+
+  it("passes explicit language-neutral instructions and upstream timeouts", async () => {
+    const client = {
+      crawl: vi.fn(async () => ({
+        baseUrl: "https://example.church",
+        results: [{
+          url: "https://example.church/creemos",
+          rawContent: "Creemos en Dios.",
+        }],
+      })),
+      extract: vi.fn(async () => ({
+        results: [],
+        failedResults: [],
+        responseTime: 0,
+        requestId: "extract-1",
+      })),
+    };
+
+    const result = await crawlChurchSite(
+      "https://example.church",
+      client as never,
+      { crawlTimeoutSeconds: 70, extractTimeoutSeconds: 25 },
+    );
+
+    expect(client.crawl).toHaveBeenCalledWith(
+      "https://example.church",
+      expect.objectContaining({
+        maxDepth: 2,
+        extractDepth: "advanced",
+        allowExternal: false,
+        timeout: 70,
+        instructions: expect.stringContaining(
+          "Do not depend on English page titles or URL words.",
+        ),
+      }),
+    );
+    expect(client.extract).toHaveBeenCalledWith(
+      ["https://example.church"],
+      expect.objectContaining({ timeout: 25 }),
+    );
+    expect(result.base_url).toBe("https://example.church");
   });
 });

--- a/lib/church-evaluation/crawl.ts
+++ b/lib/church-evaluation/crawl.ts
@@ -2,6 +2,11 @@ import { createHash } from "node:crypto";
 
 import { tavily } from "@tavily/core";
 
+import { ChurchEvaluationUpstreamError } from "./runtime";
+
+export const TAVILY_CRAWL_TIMEOUT_SECONDS = 75;
+export const TAVILY_EXTRACT_TIMEOUT_SECONDS = 30;
+
 export type ChurchSourcePage = {
   url?: string;
   requestedUrl?: string;
@@ -11,6 +16,7 @@ export type ChurchSourcePage = {
 
 export type TavilyCrawlResult = {
   base_url?: string;
+  baseUrl?: string;
   results?: ChurchSourcePage[];
 };
 
@@ -45,7 +51,8 @@ function createContentHash(text: string): string {
 
 export function dropAnchorDupes(data: TavilyCrawlResult): TavilyCrawlResult {
   const results = Array.isArray(data.results) ? data.results : [];
-  if (!results.length) return { base_url: data.base_url, results: [] };
+  const baseUrl = data.base_url ?? data.baseUrl;
+  if (!results.length) return { base_url: baseUrl, results: [] };
 
   const clean: ChurchSourcePage[] = [];
   const fragments: ChurchSourcePage[] = [];
@@ -106,16 +113,18 @@ export function dropAnchorDupes(data: TavilyCrawlResult): TavilyCrawlResult {
     normalizedResults.push(entry);
   }
 
-  return { base_url: data.base_url, results: normalizedResults };
+  return { base_url: baseUrl, results: normalizedResults };
 }
 
 export async function extractChurchPage(
   requestedUrl: string,
   client: TavilyClient = getTavilyClient(),
+  timeoutSeconds = TAVILY_EXTRACT_TIMEOUT_SECONDS,
 ): Promise<ChurchSourcePage | null> {
   const response = await client.extract([requestedUrl], {
-    extract_depth: "advanced",
+    extractDepth: "advanced",
     format: "markdown",
+    timeout: timeoutSeconds,
   }) as TavilyExtractResponse;
 
   const result = response.results?.[0];
@@ -191,22 +200,32 @@ export function createSourcePageMetadata(pages: ChurchSourcePage[]) {
 export async function crawlChurchSite(
   website: string,
   client: TavilyClient = getTavilyClient(),
+  {
+    crawlTimeoutSeconds = TAVILY_CRAWL_TIMEOUT_SECONDS,
+    extractTimeoutSeconds = TAVILY_EXTRACT_TIMEOUT_SECONDS,
+  }: {
+    crawlTimeoutSeconds?: number;
+    extractTimeoutSeconds?: number;
+  } = {},
 ): Promise<TavilyCrawlResult> {
   try {
     const [crawlResponse, rootPage] = await Promise.all([
       client.crawl(website, {
         instructions:
-          "I need the following:\n1. doctrinal statement, their beliefs, doctrine, teaching statement, or statement of faith.\n2. The address of the church/main campus.\n3. Their pastors, elders, bishops, priests, or reverends.\n4. Ministries that they have, like Biblical Counseling, Youth Group, Children's Ministry, etc.\n5. If they have home groups/community groups/life groups, etc.",
-        max_depth: 2,
-        extract_depth: "advanced",
-        allow_external: false,
+          "The website may be written in any language. Semantically locate official pages covering: the church's doctrinal statement or beliefs; church and campus addresses; clergy and governing leaders; ministries; and home, community, or small groups. Do not depend on English page titles or URL words.",
+        maxDepth: 2,
+        extractDepth: "advanced",
+        allowExternal: false,
+        timeout: crawlTimeoutSeconds,
       }),
-      extractChurchPage(website, client).catch(() => null),
+      extractChurchPage(website, client, extractTimeoutSeconds).catch(
+        () => null,
+      ),
     ]);
 
     const crawlData = crawlResponse as TavilyCrawlResult;
     const merged = {
-      base_url: crawlData.base_url || website,
+      base_url: crawlData.base_url || crawlData.baseUrl || website,
       results: [
         ...(rootPage ? [rootPage] : []),
         ...(Array.isArray(crawlData.results) ? crawlData.results : []),
@@ -215,9 +234,15 @@ export async function crawlChurchSite(
 
     return dropAnchorDupes(merged);
   } catch (error) {
-    console.error("Tavily crawl error:", error);
-    throw new Error(
-      `Failed to crawl website: ${error instanceof Error ? error.message : "Unknown error"}`,
+    console.error("church_evaluation_upstream_error", {
+      provider: "tavily",
+      stage: "crawl",
+      error_name: error instanceof Error ? error.name : "UnknownError",
+    });
+    throw new ChurchEvaluationUpstreamError(
+      "tavily",
+      "crawl",
+      { cause: error },
     );
   }
 }

--- a/lib/church-evaluation/evidence.test.ts
+++ b/lib/church-evaluation/evidence.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import type {
   CoreDoctrinesResponse,
-  CoreDoctrineKey,
   CoreDoctrineMap,
   RedFlagsResponse,
 } from "@/types/church";
@@ -48,7 +47,8 @@ describe("validateCoreDoctrineEvidence", () => {
       ),
       [{
         url: "https://example.church/beliefs",
-        rawContent: "We believe: The Bible is the inspired Word of God and our final authority.",
+        rawContent:
+          "We believe: The Bible is the inspired Word of God and our final authority.",
       }],
     );
 
@@ -74,6 +74,28 @@ describe("validateCoreDoctrineEvidence", () => {
     );
 
     expect(result.core_doctrines.resurrection_of_jesus).toBe("true");
+  });
+
+  it("retains source-grounded composite doctrine evidence in Spanish", () => {
+    const quote =
+      "Jesucristo es verdaderamente Dios y verdaderamente hombre.";
+    const result = validateCoreDoctrineEvidence(
+      response(
+        { christ_deity_humanity: "true" },
+        [{
+          label: "christ_deity_humanity",
+          text: quote,
+          source_url: "https://ejemplo.iglesia/creemos",
+        }],
+      ),
+      [{
+        url: "https://ejemplo.iglesia/creemos",
+        rawContent: `Nuestra confesión declara: ${quote}`,
+      }],
+    );
+
+    expect(result.core_doctrines.christ_deity_humanity).toBe("true");
+    expect(result.notes).toHaveLength(1);
   });
 
   it("downgrades a status with no matching note to unknown", () => {
@@ -105,288 +127,126 @@ describe("validateCoreDoctrineEvidence", () => {
     expect(result.notes).toEqual([]);
   });
 
-  it("downgrades a composite doctrine when only Christ's deity is grounded", () => {
+  it("rejects a citation to a URL outside the source set", () => {
     const result = validateCoreDoctrineEvidence(
       response(
-        { christ_deity_humanity: "true" },
+        { gospel: "true" },
         [{
-          label: "christ_deity_humanity",
-          text: "Jesus Christ is truly God.",
+          label: "gospel",
+          text: "Christ died and rose again for our salvation.",
+          source_url: "https://invented.example/faith",
+        }],
+      ),
+      [{
+        url: "https://example.church/beliefs",
+        rawContent: "Christ died and rose again for our salvation.",
+      }],
+    );
+
+    expect(result.core_doctrines.gospel).toBe("unknown");
+  });
+
+  it("rejects evidence that exceeds the structural quote limit", () => {
+    const quote = "D".repeat(501);
+    const result = validateCoreDoctrineEvidence(
+      response(
+        { trinity: "true" },
+        [{
+          label: "trinity",
+          text: quote,
           source_url: "https://example.church/beliefs",
         }],
       ),
       [{
         url: "https://example.church/beliefs",
-        rawContent: "Jesus Christ is truly God.",
+        rawContent: quote,
       }],
     );
 
-    expect(result.core_doctrines.christ_deity_humanity).toBe("unknown");
-    expect(result.notes).toEqual([]);
+    expect(result.core_doctrines.trinity).toBe("unknown");
   });
-
-  it("combines grounded notes to validate every component of a composite doctrine", () => {
-    const notes = [{
-      label: "christ_deity_humanity",
-      text: "Jesus Christ is truly God.",
-      source_url: "https://example.church/beliefs",
-    }, {
-      label: "christ_deity_humanity",
-      text: "He took upon Himself a human nature.",
-      source_url: "https://example.church/beliefs",
-    }];
-    const result = validateCoreDoctrineEvidence(
-      response({ christ_deity_humanity: "true" }, notes),
-      [{
-        url: "https://example.church/beliefs",
-        rawContent: "Jesus Christ is truly God. He took upon Himself a human nature.",
-      }],
-    );
-
-    expect(result.core_doctrines.christ_deity_humanity).toBe("true");
-    expect(result.notes).toEqual(notes);
-  });
-
-  it.each([
-    [
-      "gospel",
-      "Christ died for our sins and rose from the dead.",
-      "Salvation is by grace through faith.",
-    ],
-    [
-      "incarnation_virgin_birth",
-      "The Word became flesh.",
-      "He was conceived by the Holy Spirit and born of the Virgin Mary.",
-    ],
-    [
-      "atonement_necessary_sufficient",
-      "Christ died as an atoning sacrifice for our sins.",
-      "His death is necessary and sufficient.",
-    ],
-    [
-      "return_and_judgment",
-      "Jesus will return.",
-      "He will judge the living and the dead.",
-    ],
-    [
-      "character_of_god",
-      "God is holy and just.",
-      "God is good and merciful.",
-    ],
-  ] satisfies Array<[CoreDoctrineKey, string, string]>)(
-    "requires both grounded components for %s",
-    (key, firstComponent, secondComponent) => {
-      const sourceUrl = "https://example.church/beliefs";
-      const partial = validateCoreDoctrineEvidence(
-        response(
-          { [key]: "true" },
-          [{ label: key, text: firstComponent, source_url: sourceUrl }],
-        ),
-        [{ url: sourceUrl, rawContent: firstComponent }],
-      );
-      const completeNotes = [
-        { label: key, text: firstComponent, source_url: sourceUrl },
-        { label: key, text: secondComponent, source_url: sourceUrl },
-      ];
-      const complete = validateCoreDoctrineEvidence(
-        response({ [key]: "true" }, completeNotes),
-        [{
-          url: sourceUrl,
-          rawContent: `${firstComponent} ${secondComponent}`,
-        }],
-      );
-
-      expect(partial.core_doctrines[key]).toBe("unknown");
-      expect(complete.core_doctrines[key]).toBe("true");
-    },
-  );
 });
 
 describe("validateRedFlagEvidence", () => {
-  it("rejects the Refuge couple-list inference for Ordained Women", () => {
+  it("retains grounded Spanish clergy and textual gender evidence", () => {
+    const quote = "María López — Pastora. Ella dirige la congregación.";
     const response: RedFlagsResponse = {
       badges: ["👩‍🏫 Ordained Women"],
       notes: [{
         label: "Ordained Women",
-        text: "The church leadership page lists \"ELDERS/PASTORS\" and explicitly includes \"Courtney & Marilyn Knerr\" and other couples in this governing category. Marilyn is also described as serving together with Courtney.",
-        source_url: "https://www.myrefugecommunity.org/about",
+        text: quote,
+        source_url: "https://ejemplo.iglesia/liderazgo",
       }],
     };
 
     const result = validateRedFlagEvidence(response, [{
-      url: "https://www.myrefugecommunity.org/about",
-      rawContent: "ELDERS/PASTORS Courtney & Marilyn Knerr. The Elders/Pastors serve together alongside their wives.",
-    }]);
-
-    expect(result.badges).toEqual([]);
-    expect(result.notes).toEqual([]);
-  });
-
-  it("retains Ordained Women only for a grounded named clergy title", () => {
-    const response: RedFlagsResponse = {
-      badges: ["👩‍🏫 Ordained Women"],
-      notes: [{
-        label: "Ordained Women",
-        text: "The leadership page identifies \"Sarah Johnson — Teaching Pastor. She oversees adult discipleship.\"",
-        source_url: "https://example.church/leadership",
-      }],
-    };
-
-    const result = validateRedFlagEvidence(response, [{
-      url: "https://example.church/leadership",
-      rawContent: "Our team includes Sarah Johnson — Teaching Pastor. She oversees adult discipleship.",
+      url: "https://ejemplo.iglesia/liderazgo",
+      rawContent: `Equipo pastoral: ${quote}`,
     }]);
 
     expect(result.badges).toEqual(["👩‍🏫 Ordained Women"]);
     expect(result.notes).toEqual(response.notes);
   });
 
-  it("accepts a clergy title placed before the woman's name", () => {
+  it("accepts a requested URL when a leadership page redirects", () => {
+    const quote = "牧師の佐藤恵美。彼女は会衆を導いています。";
     const response: RedFlagsResponse = {
       badges: ["👩‍🏫 Ordained Women"],
       notes: [{
         label: "👩‍🏫 Ordained Women",
-        text: "The leadership page identifies \"Rev. Jane Doe. She serves on the pastoral team.\"",
-        source_url: "https://example.church/leadership",
+        text: quote,
+        source_url: "https://example.jp/team",
       }],
     };
 
     const result = validateRedFlagEvidence(response, [{
-      url: "https://example.church/leadership",
-      rawContent: "Rev. Jane Doe. She serves on the pastoral team.",
+      requestedUrl: "https://example.jp/team",
+      url: "https://example.jp/leaders",
+      rawContent: quote,
     }]);
 
     expect(result.badges).toEqual(["👩‍🏫 Ordained Women"]);
   });
 
-  it("accepts a grounded gendered honorific tied to the named clergy member", () => {
+  it("removes Ordained Women when its quotation is hallucinated", () => {
     const response: RedFlagsResponse = {
       badges: ["👩‍🏫 Ordained Women"],
       notes: [{
         label: "Ordained Women",
-        text: "The leadership page identifies \"Ms. Anna Lee — Associate Pastor\".",
-        source_url: "https://example.church/leadership",
+        text: "María López — Pastora. Ella dirige la congregación.",
+        source_url: "https://ejemplo.iglesia/liderazgo",
       }],
     };
 
     const result = validateRedFlagEvidence(response, [{
-      url: "https://example.church/leadership",
-      rawContent: "Ms. Anna Lee — Associate Pastor.",
-    }]);
-
-    expect(result.badges).toEqual(["👩‍🏫 Ordained Women"]);
-  });
-
-  it("rejects a grounded male clergy title mislabeled as Ordained Women", () => {
-    const response: RedFlagsResponse = {
-      badges: ["👩‍🏫 Ordained Women"],
-      notes: [{
-        label: "Ordained Women",
-        text: "The leadership page identifies \"John Smith — Pastor. He leads the congregation.\"",
-        source_url: "https://example.church/leadership",
-      }],
-    };
-
-    const result = validateRedFlagEvidence(response, [{
-      url: "https://example.church/leadership",
-      rawContent: "John Smith — Pastor. He leads the congregation.",
+      url: "https://ejemplo.iglesia/liderazgo",
+      rawContent: "María López — Directora del ministerio infantil.",
     }]);
 
     expect(result.badges).toEqual([]);
     expect(result.notes).toEqual([]);
   });
 
-  it("does not infer female identity from a name alone", () => {
+  it("preserves unrelated red flags while removing unsupported Ordained Women", () => {
     const response: RedFlagsResponse = {
-      badges: ["👩‍🏫 Ordained Women"],
+      badges: ["👩‍🏫 Ordained Women", "⚠️ Prosperity Gospel"],
       notes: [{
         label: "Ordained Women",
-        text: "The leadership page identifies \"Sarah Johnson — Teaching Pastor\".",
-        source_url: "https://example.church/leadership",
+        text: "Unsupported quotation",
+        source_url: "https://example.church/team",
+      }, {
+        label: "Prosperity Gospel",
+        text: "Giving guarantees personal wealth.",
+        source_url: "https://example.church/giving",
       }],
     };
 
     const result = validateRedFlagEvidence(response, [{
-      url: "https://example.church/leadership",
-      rawContent: "Sarah Johnson — Teaching Pastor.",
+      url: "https://example.church/giving",
+      rawContent: "Giving guarantees personal wealth.",
     }]);
 
-    expect(result.badges).toEqual([]);
-    expect(result.notes).toEqual([]);
-  });
-
-  it("does not apply another person's pronoun to a named male pastor", () => {
-    const response: RedFlagsResponse = {
-      badges: ["👩‍🏫 Ordained Women"],
-      notes: [{
-        label: "Ordained Women",
-        text: "The leadership page identifies \"John Smith — Pastor; Jane coordinates outreach. She leads the women's ministry.\"",
-        source_url: "https://example.church/leadership",
-      }],
-    };
-
-    const result = validateRedFlagEvidence(response, [{
-      url: "https://example.church/leadership",
-      rawContent: "John Smith — Pastor; Jane coordinates outreach. She leads the women's ministry.",
-    }]);
-
-    expect(result.badges).toEqual([]);
-    expect(result.notes).toEqual([]);
-  });
-
-  it("does not apply another person's stated pronouns to a named male pastor", () => {
-    const response: RedFlagsResponse = {
-      badges: ["👩‍🏫 Ordained Women"],
-      notes: [{
-        label: "Ordained Women",
-        text: "The leadership page identifies \"John Smith — Pastor; Jane Doe (she/her) coordinates outreach.\"",
-        source_url: "https://example.church/leadership",
-      }],
-    };
-
-    const result = validateRedFlagEvidence(response, [{
-      url: "https://example.church/leadership",
-      rawContent: "John Smith — Pastor; Jane Doe (she/her) coordinates outreach.",
-    }]);
-
-    expect(result.badges).toEqual([]);
-    expect(result.notes).toEqual([]);
-  });
-
-  it("accepts stated pronouns only when attached to the named clergy member", () => {
-    const response: RedFlagsResponse = {
-      badges: ["👩‍🏫 Ordained Women"],
-      notes: [{
-        label: "Ordained Women",
-        text: "The leadership page identifies \"Sarah Johnson (she/her) — Teaching Pastor\".",
-        source_url: "https://example.church/leadership",
-      }],
-    };
-
-    const result = validateRedFlagEvidence(response, [{
-      url: "https://example.church/leadership",
-      rawContent: "Sarah Johnson (she/her) — Teaching Pastor.",
-    }]);
-
-    expect(result.badges).toEqual(["👩‍🏫 Ordained Women"]);
-  });
-
-  it("rejects an explicit title that cannot be found on the cited page", () => {
-    const response: RedFlagsResponse = {
-      badges: ["👩‍🏫 Ordained Women"],
-      notes: [{
-        label: "Ordained Women",
-        text: "The leadership page identifies \"Sarah Johnson — Teaching Pastor. She oversees adult discipleship.\"",
-        source_url: "https://example.church/leadership",
-      }],
-    };
-
-    const result = validateRedFlagEvidence(response, [{
-      url: "https://example.church/leadership",
-      rawContent: "Sarah Johnson — Children's Ministry Director. She oversees adult discipleship.",
-    }]);
-
-    expect(result.badges).toEqual([]);
-    expect(result.notes).toEqual([]);
+    expect(result.badges).toEqual(["⚠️ Prosperity Gospel"]);
+    expect(result.notes).toEqual([response.notes[1]]);
   });
 });

--- a/lib/church-evaluation/evidence.ts
+++ b/lib/church-evaluation/evidence.ts
@@ -7,81 +7,7 @@ import type {
 } from "../../types/church";
 import { CORE_DOCTRINE_KEYS } from "../schemas/church-finder";
 
-const ORDAINED_WOMEN_BADGE = "👩‍🏫 Ordained Women";
-const NAME_TOKEN =
-  String.raw`(?:[A-Z]\.|[A-Z][A-Za-zÀ-ÖØ-öø-ÿ'’.-]*[A-Za-zÀ-ÖØ-öø-ÿ'’])`;
-const PERSON_NAME = String.raw`${NAME_TOKEN}(?:\s+${NAME_TOKEN}){1,3}`;
-const CLERGY_OFFICE =
-  String.raw`(?:[Pp]astor|PASTOR|[Ee]lder|ELDER|[Rr]ev(?:erend)?\.?|REV(?:EREND)?\.?|[Bb]ishop|BISHOP|[Pp]riest|PRIEST)`;
-const OFFICE_MODIFIER =
-  String.raw`(?:[Ll]ead|[Tt]eaching|[Aa]ssociate|[Ee]xecutive|[Ss]enior|[Cc]ampus|[Ww]orship|[Cc]hildren(?:'s|’s)?|[Yy]outh|[Ff]amily|[Dd]iscipleship|[Mm]issions?)`;
-const TITLED_OFFICE = String.raw`(?:${OFFICE_MODIFIER}\s+)*${CLERGY_OFFICE}`;
-const STATED_FEMALE_PRONOUNS = String.raw`\(\s*she\s*\/\s*(?:her|hers)\s*\)`;
-
-const REQUIRED_TRUE_COMPONENTS: Partial<
-  Record<CoreDoctrineKey, readonly (readonly RegExp[])[]>
-> = {
-  gospel: [
-    [
-      /\b(?:christ|jesus|he)(?:'s)?\b.{0,50}\b(?:died|death|cross|shed his blood)\b/i,
-      /\bchrist's (?:saving |sacrificial |atoning )?death\b/i,
-    ],
-    [/\b(?:rose|risen|resurrection|raised) from the dead\b/i, /\bbodily resurrection\b/i],
-    [
-      /\b(?:saved|salvation|justified)\b.{0,50}\b(?:grace\b.{0,50}\bfaith|faith\b.{0,50}\bgrace)\b/i,
-      /\bfaith alone\b/i,
-      /\bby grace through faith\b/i,
-    ],
-  ],
-  christ_deity_humanity: [
-    [
-      /\bjesus(?: christ)? is (?:fully |truly |eternally )?god\b/i,
-      /\b(?:fully|truly|eternally) god\b/i,
-      /\bgod incarnate\b/i,
-      /\bdivine nature\b/i,
-    ],
-    [
-      /\b(?:fully|truly|really) (?:man|human)\b/i,
-      /\bhuman nature\b/i,
-      /\b(?:god|the word) became (?:man|flesh)\b/i,
-      /\btook (?:on|upon himself) (?:a )?human nature\b/i,
-    ],
-  ],
-  incarnation_virgin_birth: [
-    [
-      /\bincarnat(?:e|ed|ion)\b/i,
-      /\b(?:god|the word) became (?:man|flesh)\b/i,
-      /\btook (?:on|upon himself) (?:a )?human nature\b/i,
-    ],
-    [
-      /\bvirgin birth\b/i,
-      /\bborn (?:of|to) (?:the )?virgin mary\b/i,
-      /\bconceived by (?:the )?holy spirit\b/i,
-    ],
-  ],
-  atonement_necessary_sufficient: [
-    [
-      /\b(?:christ|jesus|he)(?:'s)?\b.{0,50}\b(?:died|death|cross|aton\w*|sacrific\w*|blood|propitiat\w*|ransom\w*|reconcil\w*)\b/i,
-      /\b(?:atoning|substitutionary) sacrifice\b/i,
-    ],
-    [
-      /\b(?:only|sole|unique)\b.{0,40}\b(?:way|means|mediator|savior|salvation|atonement|sacrifice)\b/i,
-      /\b(?:sufficient|once for all|fully paid)\b/i,
-      /\bnecessary and sufficient\b/i,
-    ],
-  ],
-  return_and_judgment: [
-    [
-      /\b(?:christ|jesus|he)\b.{0,30}\b(?:will|shall) (?:return|come again)\b/i,
-      /\bsecond coming\b/i,
-    ],
-    [/\b(?:judge|judgment|judgement)\b/i],
-  ],
-  character_of_god: [
-    [/\b(?:holy|just|righteous|wrath|judge|judgment|judgement)\b/i],
-    [/\b(?:good|loving|love|merciful|mercy|gracious|grace|faithful)\b/i],
-  ],
-};
+const MAX_EVIDENCE_QUOTE_CODE_POINTS = 500;
 
 export type EvidenceSourcePage = {
   url?: string;
@@ -141,103 +67,45 @@ function isGroundedNote(
   note: ChurchNote,
   pages: EvidenceSourcePage[],
 ): boolean {
-  if (!note.text.trim()) return false;
+  const evidence = note.text.trim();
+  if (
+    !evidence ||
+    Array.from(evidence).length > MAX_EVIDENCE_QUOTE_CODE_POINTS
+  ) {
+    return false;
+  }
 
   const sourcePage = findSourcePage(note, pages);
   if (!sourcePage?.rawContent) return false;
 
   return normalizeEvidenceText(sourcePage.rawContent)
-    .includes(normalizeEvidenceText(note.text));
+    .includes(normalizeEvidenceText(evidence));
 }
 
-function extractQuotedEvidence(value: string): string[] {
-  return [...value.matchAll(/["“]([^"”]+)["”]/g)]
-    .map((match) => match[1]?.trim())
-    .filter((quote): quote is string => Boolean(quote));
+function normalizeCanonicalLabel(value: string): string {
+  return value
+    .normalize("NFKC")
+    .trim()
+    .toLowerCase()
+    .replace(/^[^\p{L}\p{N}]+/u, "")
+    .replace(/\s+/g, " ");
 }
 
-function extractExplicitNamedClergyName(value: string): string | null {
-  const officeBeforeName = new RegExp(
-    String.raw`(?:^|[\s.,;:—–-])${TITLED_OFFICE}\s+(${PERSON_NAME})(?:\s*${STATED_FEMALE_PRONOUNS})?(?:$|[\s.,;:—–-])`,
-  );
-  const nameBeforeOffice = new RegExp(
-    String.raw`(?:^|[\s.,;:—–-])(${PERSON_NAME})(?:\s*${STATED_FEMALE_PRONOUNS})?\s*(?:,|:|—|–|-)\s*${TITLED_OFFICE}(?:$|[\s.,;:—–-])`,
-  );
-
-  return officeBeforeName.exec(value)?.[1] ??
-    nameBeforeOffice.exec(value)?.[1] ??
-    null;
+function noteMatchesBadge(note: ChurchNote, badge: string): boolean {
+  return normalizeCanonicalLabel(note.label) === normalizeCanonicalLabel(badge);
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function hasExplicitFemaleIdentity(
-  value: string,
-  personName: string,
-): boolean {
-  const escapedName = escapeRegExp(personName);
-  const genderedHonorific = new RegExp(
-    String.raw`(?:^|[\s,;:—–-])(?:Ms|Mrs|Miss)\.?\s+${escapedName}(?:$|[\s.,;:—–-])`,
-    "i",
-  );
-  const statedPronouns = new RegExp(
-    String.raw`(?:${escapedName}\s*${STATED_FEMALE_PRONOUNS}|${STATED_FEMALE_PRONOUNS}\s*${escapedName})`,
-    "i",
-  );
-  const connectedFemalePronoun = new RegExp(
-    String.raw`(?:${escapedName}(?:\s*${STATED_FEMALE_PRONOUNS})?\s*(?:,|:|—|–|-)\s*${TITLED_OFFICE}|${TITLED_OFFICE}\s+${escapedName}(?:\s*${STATED_FEMALE_PRONOUNS})?)\s*[.!?]\s*(?:she|her)\b`,
-    "i",
-  );
-  const explicitFemaleDescription = new RegExp(
-    String.raw`\b${escapedName}\s+(?:is|identifies as)\s+(?:a\s+)?(?:woman|female)\b`,
-    "i",
-  );
-
-  return genderedHonorific.test(value) ||
-    statedPronouns.test(value) ||
-    connectedFemalePronoun.test(value) ||
-    explicitFemaleDescription.test(value);
-}
-
-function hasCompleteCompositeEvidence(
-  key: CoreDoctrineKey,
+export function filterGroundedNotes(
   notes: ChurchNote[],
-): boolean {
-  const requiredComponents = REQUIRED_TRUE_COMPONENTS[key];
-  if (!requiredComponents) return true;
-
-  const evidenceText = notes.map((note) => note.text).join(" ");
-  return requiredComponents.every((patterns) =>
-    patterns.some((pattern) => pattern.test(evidenceText))
-  );
-}
-
-function isOrdainedWomenNote(note: ChurchNote): boolean {
-  return normalizeEvidenceText(note.label).includes("ordained women");
-}
-
-function isGroundedOrdainedWomenNote(
-  note: ChurchNote,
   pages: EvidenceSourcePage[],
-): boolean {
-  const sourcePage = findSourcePage(note, pages);
-  if (!sourcePage?.rawContent) return false;
-
-  const normalizedSource = normalizeEvidenceText(sourcePage.rawContent);
-  return extractQuotedEvidence(note.text).some((quote) => {
-    const personName = extractExplicitNamedClergyName(quote);
-    return personName !== null &&
-      hasExplicitFemaleIdentity(quote, personName) &&
-      normalizedSource.includes(normalizeEvidenceText(quote));
-  });
+): ChurchNote[] {
+  return notes.filter((note) => isGroundedNote(note, pages));
 }
 
 /**
- * Fail closed when an LLM returns a doctrine status without a source-grounded
- * quotation. Positive composite doctrines must also contain grounded evidence
- * for every component; a partial affirmation is downgraded to unknown.
+ * Fail closed when an LLM returns a doctrine status without a short,
+ * source-grounded quotation. Semantic completeness is handled by the
+ * structured multilingual extraction prompt rather than a language allowlist.
  */
 export function validateCoreDoctrineEvidence(
   response: CoreDoctrinesResponse,
@@ -259,13 +127,7 @@ export function validateCoreDoctrineEvidence(
       (note) => normalizeDoctrineLabel(note.label) === key,
     );
 
-    const hasSufficientEvidence = matchingGroundedNotes.length > 0 &&
-      (
-        status !== "true" ||
-        hasCompleteCompositeEvidence(key, matchingGroundedNotes)
-      );
-
-    acc[key] = hasSufficientEvidence ? status : "unknown";
+    acc[key] = matchingGroundedNotes.length > 0 ? status : "unknown";
     return acc;
   }, {} as CoreDoctrineMap);
 
@@ -279,38 +141,23 @@ export function validateCoreDoctrineEvidence(
 }
 
 /**
- * A generic leadership heading, a couple listing, or language about elders
- * serving alongside their wives does not establish that a woman holds an
- * ordained office. Keep this critical badge only when a single verbatim,
- * source-grounded quotation directly joins a named individual to a clergy
- * title and explicitly identifies that officeholder as a woman.
+ * Keep deterministic red-flag validation structural and language-neutral.
+ * The extraction prompt owns badge semantics; code only requires each badge to
+ * have a matching short quotation grounded in the cited source.
  */
 export function validateRedFlagEvidence(
   response: RedFlagsResponse,
   pages: EvidenceSourcePage[],
 ): RedFlagsResponse {
-  if (!response.badges.includes(ORDAINED_WOMEN_BADGE)) {
-    return response;
-  }
-
-  const validOrdainedWomenNotes = response.notes.filter(
-    (note) =>
-      isOrdainedWomenNote(note) &&
-      isGroundedOrdainedWomenNote(note, pages),
+  const groundedNotes = filterGroundedNotes(response.notes, pages);
+  const groundedBadges = response.badges.filter((badge) =>
+    groundedNotes.some((note) => noteMatchesBadge(note, badge))
   );
 
-  if (validOrdainedWomenNotes.length === 0) {
-    return {
-      badges: response.badges.filter((badge) => badge !== ORDAINED_WOMEN_BADGE),
-      notes: response.notes.filter((note) => !isOrdainedWomenNote(note)),
-    };
-  }
-
   return {
-    badges: response.badges,
-    notes: [
-      ...response.notes.filter((note) => !isOrdainedWomenNote(note)),
-      ...validOrdainedWomenNotes,
-    ],
+    badges: groundedBadges,
+    notes: groundedNotes.filter((note) =>
+      groundedBadges.some((badge) => noteMatchesBadge(note, badge))
+    ),
   };
 }

--- a/lib/church-evaluation/extract.test.ts
+++ b/lib/church-evaluation/extract.test.ts
@@ -1,0 +1,171 @@
+import { GoogleGenAI, ThinkingLevel } from "@google/genai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CORE_EXTRACTION_THINKING_LEVEL,
+  EVALUATION_MODEL,
+  EVALUATION_PROMPT_VERSION,
+  extractChurchEvaluation,
+} from "./extract";
+
+const unknownCore = {
+  trinity: "unknown",
+  gospel: "unknown",
+  justification_by_faith: "unknown",
+  christ_deity_humanity: "true",
+  scripture_authority: "unknown",
+  incarnation_virgin_birth: "unknown",
+  atonement_necessary_sufficient: "unknown",
+  resurrection_of_jesus: "unknown",
+  return_and_judgment: "unknown",
+  character_of_god: "unknown",
+};
+
+describe("extractChurchEvaluation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses model-selected multilingual pages and the stable Gemini configuration", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const responses = [
+      {
+        name: "Iglesia Ejemplo",
+        website: "https://ejemplo.iglesia/",
+        addresses: [],
+        contacts: { phone: null, email: null },
+        service_times: [],
+        best_pages_for: {
+          beliefs: "https://ejemplo.iglesia/creemos",
+          confession: null,
+          about: null,
+          leadership: "https://ejemplo.iglesia/liderazgo",
+        },
+      },
+      {
+        core_doctrines: unknownCore,
+        notes: [{
+          label: "christ_deity_humanity",
+          text:
+            "Jesucristo es verdaderamente Dios y verdaderamente hombre.",
+          source_url: "https://ejemplo.iglesia/creemos",
+        }],
+      },
+      {
+        secondary: {
+          baptism: null,
+          governance: null,
+          lords_supper: null,
+          gifts: null,
+          sanctification: null,
+          continuity: null,
+          security: null,
+          atonement_model: null,
+        },
+        badges: [],
+      },
+      {
+        tertiary: {
+          eschatology: null,
+          worship_style: null,
+          counseling: null,
+          creation: null,
+          christian_liberty: null,
+          discipline: null,
+          parachurch: null,
+          marriage_roles: null,
+        },
+        badges: [],
+      },
+      {
+        denomination: {
+          label: null,
+          confidence: 0,
+          signals: [],
+        },
+        confession: {
+          adopted: false,
+          name: null,
+          source_url: null,
+        },
+        badges: [],
+        notes: [],
+      },
+      {
+        badges: ["👩‍🏫 Ordained Women"],
+        notes: [{
+          label: "Ordained Women",
+          text: "María López — Pastora. Ella dirige la congregación.",
+          source_url: "https://ejemplo.iglesia/liderazgo",
+        }],
+      },
+    ];
+    const generateContent = vi.fn();
+    for (const response of responses) {
+      generateContent.mockResolvedValueOnce({
+        text: JSON.stringify(response),
+      });
+    }
+    const client = {
+      models: { generateContent },
+    } as unknown as GoogleGenAI;
+    const crawl = vi.fn(async () => ({
+      base_url: "https://ejemplo.iglesia/",
+      results: [{
+        url: "https://ejemplo.iglesia/beliefs",
+        rawContent: "Página de inicio.",
+      }],
+    }));
+    const extractPage = vi.fn(async (url: string) => ({
+      requestedUrl: url,
+      url,
+      rawContent: url.endsWith("/creemos")
+        ? "Jesucristo es verdaderamente Dios y verdaderamente hombre."
+        : "María López — Pastora. Ella dirige la congregación.",
+      favicon: null,
+    }));
+
+    const result = await extractChurchEvaluation(
+      "https://ejemplo.iglesia/",
+      { client, crawl, extractPage },
+    );
+
+    expect(extractPage).toHaveBeenCalledTimes(2);
+    expect(extractPage).toHaveBeenCalledWith(
+      "https://ejemplo.iglesia/creemos",
+    );
+    expect(extractPage).toHaveBeenCalledWith(
+      "https://ejemplo.iglesia/liderazgo",
+    );
+    expect(extractPage).not.toHaveBeenCalledWith(
+      "https://ejemplo.iglesia/beliefs",
+    );
+    expect(generateContent).toHaveBeenCalledTimes(6);
+    expect(generateContent.mock.calls.every(
+      ([request]) => request.model === "gemini-3.6-flash",
+    )).toBe(true);
+    expect(
+      generateContent.mock.calls[1][0].config.thinkingConfig.thinkingLevel,
+    ).toBe(ThinkingLevel.MEDIUM);
+    for (const call of generateContent.mock.calls.filter((_, index) =>
+      index !== 1
+    )) {
+      expect(call[0].config.thinkingConfig.thinkingLevel).toBe(
+        ThinkingLevel.LOW,
+      );
+    }
+    expect(result.church.core_doctrines.christ_deity_humanity).toBe("true");
+    expect(result.church.badges).toContain("👩‍🏫 Ordained Women");
+    expect(result.metadata).toMatchObject({
+      model: "gemini-3.6-flash",
+      prompt_version: EVALUATION_PROMPT_VERSION,
+    });
+    expect(result.metadata?.source_pages).toHaveLength(3);
+  });
+
+  it("exports the production model and medium core thinking level", () => {
+    expect(EVALUATION_MODEL).toBe("gemini-3.6-flash");
+    expect(CORE_EXTRACTION_THINKING_LEVEL).toBe(ThinkingLevel.MEDIUM);
+    expect(EVALUATION_PROMPT_VERSION).not.toBe("2026-07-26");
+  });
+});

--- a/lib/church-evaluation/extract.ts
+++ b/lib/church-evaluation/extract.ts
@@ -40,16 +40,27 @@ import {
   type ChurchSourcePage,
 } from "./crawl";
 import {
+  filterGroundedNotes,
   validateCoreDoctrineEvidence,
   validateRedFlagEvidence,
 } from "./evidence";
 import { EVALUATION_POLICY_VERSION } from "./policy";
+import {
+  ChurchEvaluationTimeoutError,
+  ChurchEvaluationUpstreamError,
+  createEvaluationDeadline,
+  GEMINI_STAGE_TIMEOUT_MS,
+  runEvaluationStage,
+  TAVILY_CRAWL_STAGE_TIMEOUT_MS,
+  TAVILY_ENRICHMENT_STAGE_TIMEOUT_MS,
+} from "./runtime";
 
-export const EVALUATION_MODEL = "gemini-3-flash-preview";
-export const EVALUATION_PROMPT_VERSION = "2026-07-26";
+export const EVALUATION_MODEL = "gemini-3.6-flash";
+export const EVALUATION_PROMPT_VERSION = "2026-07-28";
+export const CORE_EXTRACTION_THINKING_LEVEL = ThinkingLevel.MEDIUM;
 
 const SYSTEM_PROMPT =
-  "You are a research analyst helping Calvinist Parrot Ministries vet churches. Produce precise, source-grounded JSON according to the schema.";
+  "You are a multilingual research analyst helping Calvinist Parrot Ministries vet churches. Interpret official content semantically in its source language and produce precise, source-grounded JSON according to the schema.";
 
 let genaiClient: GoogleGenAI | null = null;
 
@@ -68,6 +79,7 @@ async function generateStructuredResponse<T>({
   contentBlocks,
   responseSchema,
   label,
+  signal,
   thinkingLevel = ThinkingLevel.LOW,
 }: {
   client: GoogleGenAI;
@@ -75,29 +87,46 @@ async function generateStructuredResponse<T>({
   contentBlocks: string;
   responseSchema: unknown;
   label: string;
+  signal: AbortSignal;
   thinkingLevel?: ThinkingLevel;
 }): Promise<T> {
-  const response = await client.models.generateContent({
-    model: EVALUATION_MODEL,
-    contents: [{
-      role: "user",
-      parts: [{
-        text: `${SYSTEM_PROMPT}\n\n${prompt}\n\n${contentBlocks}`,
+  try {
+    const response = await client.models.generateContent({
+      model: EVALUATION_MODEL,
+      contents: [{
+        role: "user",
+        parts: [{
+          text: `${SYSTEM_PROMPT}\n\n${prompt}\n\n${contentBlocks}`,
+        }],
       }],
-    }],
-    config: {
-      responseMimeType: "application/json",
-      responseSchema: responseSchema as Schema,
-      seed: 1689,
-      thinkingConfig: { thinkingLevel },
-    },
-  });
+      config: {
+        abortSignal: signal,
+        responseMimeType: "application/json",
+        responseSchema: responseSchema as Schema,
+        seed: 1689,
+        thinkingConfig: { thinkingLevel },
+      },
+    });
 
-  if (!response.text) {
-    throw new Error(`Empty response from ${label}`);
+    if (!response.text) {
+      throw new Error(`Empty response from ${label}`);
+    }
+
+    return JSON.parse(response.text) as T;
+  } catch (error) {
+    if (
+      signal.aborted &&
+      signal.reason instanceof ChurchEvaluationTimeoutError
+    ) {
+      throw signal.reason;
+    }
+
+    throw new ChurchEvaluationUpstreamError(
+      "gemini",
+      label,
+      { cause: error },
+    );
   }
-
-  return JSON.parse(response.text) as T;
 }
 
 function assertAccessiblePages(
@@ -105,7 +134,10 @@ function assertAccessiblePages(
   pages: ChurchSourcePage[],
 ): void {
   if (!pages.length) {
-    console.error("No pages found after crawl", { website });
+    console.error("church_evaluation_no_pages", {
+      website_hostname: new URL(website).hostname,
+      source_page_count: 0,
+    });
     throw new Error(
       "Unable to gather website content for evaluation. The website may be blocking crawlers or may not have accessible content. Please try a different church website.",
     );
@@ -132,9 +164,11 @@ function assertAccessiblePages(
     (content.length < 1000 && matchedKeywords.length > 0);
 
   if (isBlocked) {
-    console.error("Single crawled page appears to be blocked", {
-      website,
-      page: pages[0],
+    console.error("church_evaluation_access_blocked", {
+      website_hostname: new URL(website).hostname,
+      source_page_count: 1,
+      input_character_count: content.length,
+      matched_block_signal_count: matchedKeywords.length,
     });
     throw new Error(
       "Unable to access website content - the site is blocking automated access. This website uses security measures (like Cloudflare) that prevent evaluation. Please try contacting the church directly or checking if they have their doctrinal statement on another platform.",
@@ -145,6 +179,7 @@ function assertAccessiblePages(
 async function enrichPages(
   pages: ChurchSourcePage[],
   urls: string[],
+  extractPage: typeof extractChurchPage,
 ): Promise<ChurchSourcePage[]> {
   const uniqueUrls = [...new Set(urls.map((url) => url.trim()).filter(Boolean))];
   if (!uniqueUrls.length) return pages;
@@ -152,9 +187,11 @@ async function enrichPages(
   const extractedPages = await Promise.all(
     uniqueUrls.map(async (url) => {
       try {
-        return await extractChurchPage(url);
+        return await extractPage(url);
       } catch (error) {
-        console.warn(`Failed to extract church page ${url}:`, error);
+        console.warn("church_evaluation_enrichment_page_failed", {
+          error_name: error instanceof Error ? error.name : "UnknownError",
+        });
         return null;
       }
     }),
@@ -167,40 +204,60 @@ async function enrichPages(
   );
 }
 
+type ChurchEvaluationDependencies = {
+  client?: GoogleGenAI;
+  crawl?: typeof crawlChurchSite;
+  extractPage?: typeof extractChurchPage;
+};
+
+function contentCharacterCount(pages: ChurchSourcePage[]): number {
+  return pages.reduce(
+    (total, page) => total + (page.rawContent?.length ?? 0),
+    0,
+  );
+}
+
 export async function extractChurchEvaluation(
   website: string,
+  dependencies: ChurchEvaluationDependencies = {},
 ): Promise<ChurchEvaluationRaw> {
-  const client = getGenaiClient();
-  const crawl = await crawlChurchSite(website);
+  const client = dependencies.client ?? getGenaiClient();
+  const crawlSite = dependencies.crawl ?? crawlChurchSite;
+  const extractPage = dependencies.extractPage ?? extractChurchPage;
+  const deadlineAt = createEvaluationDeadline();
+  const crawl = await runEvaluationStage({
+    stage: "tavily_crawl",
+    deadlineAt,
+    maxDurationMs: TAVILY_CRAWL_STAGE_TIMEOUT_MS,
+    operation: () => crawlSite(website),
+    resultDimensions: (result) => ({
+      sourcePageCount: result.results?.length ?? 0,
+      inputCharacterCount: contentCharacterCount(result.results ?? []),
+    }),
+  });
   let pages = Array.isArray(crawl.results) ? crawl.results : [];
 
   assertAccessiblePages(website, pages);
 
-  const beliefUrlPatterns = [
-    /statement[_-]?of[_-]?faith/i,
-    /beliefs?/i,
-    /doctrine/i,
-    /what[_-]?we[_-]?believe/i,
-    /confession/i,
-    /\bfaith\b/i,
-  ];
-
-  const beliefCandidates = pages
-    .map((page) => page.url?.trim())
-    .filter((url): url is string => Boolean(url))
-    .filter((url) => beliefUrlPatterns.some((pattern) => pattern.test(url)));
-
-  pages = await enrichPages(pages, beliefCandidates);
-
   let contentBlocks =
     `Base URL: ${crawl.base_url ?? website}\n\n${toChurchContentBlocks(pages)}`;
 
-  const basicFields = await generateStructuredResponse<BasicFieldsResponse>({
-    client,
-    prompt: BASIC_FIELDS_PROMPT,
-    contentBlocks,
-    responseSchema: BASIC_FIELDS_SCHEMA,
-    label: "Basic Fields extraction",
+  const basicFields = await runEvaluationStage({
+    stage: "gemini_basic_fields",
+    deadlineAt,
+    maxDurationMs: GEMINI_STAGE_TIMEOUT_MS,
+    dimensions: {
+      sourcePageCount: pages.length,
+      inputCharacterCount: contentBlocks.length,
+    },
+    operation: (signal) => generateStructuredResponse<BasicFieldsResponse>({
+      client,
+      prompt: BASIC_FIELDS_PROMPT,
+      contentBlocks,
+      responseSchema: BASIC_FIELDS_SCHEMA,
+      label: "basic_fields",
+      signal,
+    }),
   });
 
   const bestPages = Object.values(basicFields.best_pages_for ?? {})
@@ -208,7 +265,20 @@ export async function extractChurchEvaluation(
       typeof url === "string" && url.trim().length > 0
     );
 
-  pages = await enrichPages(pages, bestPages);
+  pages = await runEvaluationStage({
+    stage: "tavily_enrichment",
+    deadlineAt,
+    maxDurationMs: TAVILY_ENRICHMENT_STAGE_TIMEOUT_MS,
+    dimensions: {
+      sourcePageCount: pages.length,
+      inputCharacterCount: contentCharacterCount(pages),
+    },
+    operation: () => enrichPages(pages, bestPages, extractPage),
+    resultDimensions: (result) => ({
+      sourcePageCount: result.length,
+      inputCharacterCount: contentCharacterCount(result),
+    }),
+  });
   contentBlocks =
     `Base URL: ${crawl.base_url ?? website}\n\n${toChurchContentBlocks(pages)}`;
 
@@ -219,46 +289,103 @@ export async function extractChurchEvaluation(
     denominationConfession,
     redFlags,
   ] = await Promise.all([
-    generateStructuredResponse<CoreDoctrinesResponse>({
-      client,
-      prompt: CORE_DOCTRINES_PROMPT,
-      contentBlocks,
-      responseSchema: CORE_DOCTRINES_SCHEMA,
-      label: "Core Doctrines extraction",
-      thinkingLevel: ThinkingLevel.HIGH,
+    runEvaluationStage({
+      stage: "gemini_core_doctrines",
+      deadlineAt,
+      maxDurationMs: GEMINI_STAGE_TIMEOUT_MS,
+      dimensions: {
+        sourcePageCount: pages.length,
+        inputCharacterCount: contentBlocks.length,
+      },
+      operation: (signal) => generateStructuredResponse<CoreDoctrinesResponse>({
+        client,
+        prompt: CORE_DOCTRINES_PROMPT,
+        contentBlocks,
+        responseSchema: CORE_DOCTRINES_SCHEMA,
+        label: "core_doctrines",
+        signal,
+        thinkingLevel: CORE_EXTRACTION_THINKING_LEVEL,
+      }),
     }),
-    generateStructuredResponse<SecondaryDoctrinesResponse>({
-      client,
-      prompt: SECONDARY_DOCTRINES_PROMPT,
-      contentBlocks,
-      responseSchema: SECONDARY_DOCTRINES_SCHEMA,
-      label: "Secondary Doctrines extraction",
+    runEvaluationStage({
+      stage: "gemini_secondary_doctrines",
+      deadlineAt,
+      maxDurationMs: GEMINI_STAGE_TIMEOUT_MS,
+      dimensions: {
+        sourcePageCount: pages.length,
+        inputCharacterCount: contentBlocks.length,
+      },
+      operation: (signal) =>
+        generateStructuredResponse<SecondaryDoctrinesResponse>({
+          client,
+          prompt: SECONDARY_DOCTRINES_PROMPT,
+          contentBlocks,
+          responseSchema: SECONDARY_DOCTRINES_SCHEMA,
+          label: "secondary_doctrines",
+          signal,
+        }),
     }),
-    generateStructuredResponse<TertiaryDoctrinesResponse>({
-      client,
-      prompt: TERTIARY_DOCTRINES_PROMPT,
-      contentBlocks,
-      responseSchema: TERTIARY_DOCTRINES_SCHEMA,
-      label: "Tertiary Doctrines extraction",
+    runEvaluationStage({
+      stage: "gemini_tertiary_doctrines",
+      deadlineAt,
+      maxDurationMs: GEMINI_STAGE_TIMEOUT_MS,
+      dimensions: {
+        sourcePageCount: pages.length,
+        inputCharacterCount: contentBlocks.length,
+      },
+      operation: (signal) =>
+        generateStructuredResponse<TertiaryDoctrinesResponse>({
+          client,
+          prompt: TERTIARY_DOCTRINES_PROMPT,
+          contentBlocks,
+          responseSchema: TERTIARY_DOCTRINES_SCHEMA,
+          label: "tertiary_doctrines",
+          signal,
+        }),
     }),
-    generateStructuredResponse<DenominationConfessionResponse>({
-      client,
-      prompt: DENOMINATION_CONFESSION_PROMPT,
-      contentBlocks,
-      responseSchema: DENOMINATION_CONFESSION_SCHEMA,
-      label: "Denomination and Confession extraction",
+    runEvaluationStage({
+      stage: "gemini_denomination_confession",
+      deadlineAt,
+      maxDurationMs: GEMINI_STAGE_TIMEOUT_MS,
+      dimensions: {
+        sourcePageCount: pages.length,
+        inputCharacterCount: contentBlocks.length,
+      },
+      operation: (signal) =>
+        generateStructuredResponse<DenominationConfessionResponse>({
+          client,
+          prompt: DENOMINATION_CONFESSION_PROMPT,
+          contentBlocks,
+          responseSchema: DENOMINATION_CONFESSION_SCHEMA,
+          label: "denomination_confession",
+          signal,
+        }),
     }),
-    generateStructuredResponse<RedFlagsResponse>({
-      client,
-      prompt: RED_FLAGS_PROMPT,
-      contentBlocks,
-      responseSchema: RED_FLAGS_SCHEMA,
-      label: "Red Flags extraction",
+    runEvaluationStage({
+      stage: "gemini_red_flags",
+      deadlineAt,
+      maxDurationMs: GEMINI_STAGE_TIMEOUT_MS,
+      dimensions: {
+        sourcePageCount: pages.length,
+        inputCharacterCount: contentBlocks.length,
+      },
+      operation: (signal) => generateStructuredResponse<RedFlagsResponse>({
+        client,
+        prompt: RED_FLAGS_PROMPT,
+        contentBlocks,
+        responseSchema: RED_FLAGS_SCHEMA,
+        label: "red_flags",
+        signal,
+      }),
     }),
   ]);
 
   const groundedCore = validateCoreDoctrineEvidence(coreDoctrinesRaw, pages);
   const groundedRedFlags = validateRedFlagEvidence(redFlags, pages);
+  const groundedDenominationNotes = filterGroundedNotes(
+    denominationConfession.notes,
+    pages,
+  );
   const secondary = applyConfessionToSecondary(
     secondaryRaw.secondary,
     denominationConfession.confession.name,
@@ -293,7 +420,7 @@ export async function extractChurchEvaluation(
       ],
       notes: [
         ...groundedCore.notes,
-        ...denominationConfession.notes,
+        ...groundedDenominationNotes,
         ...groundedRedFlags.notes,
       ],
     },

--- a/lib/church-evaluation/geocode.ts
+++ b/lib/church-evaluation/geocode.ts
@@ -31,7 +31,9 @@ export async function geocodeAddress(
     const response = await fetch(url.toString(), { signal });
 
     if (!response.ok) {
-      console.warn(`Geocode failed for "${query}": HTTP ${response.status}`);
+      console.warn("church_geocoding_upstream_failed", {
+        http_status: response.status,
+      });
       return { latitude: null, longitude: null };
     }
 
@@ -45,7 +47,7 @@ export async function geocodeAddress(
 
     const coordinates = data.features?.[0]?.geometry?.coordinates;
     if (!coordinates || coordinates.length !== 2) {
-      console.warn(`No valid geocode results found for: ${query}`);
+      console.warn("church_geocoding_no_results");
       return { latitude: null, longitude: null };
     }
 
@@ -58,7 +60,9 @@ export async function geocodeAddress(
     if ((error as Error).name === "AbortError") {
       throw error;
     }
-    console.error(`Geocode error for "${query}":`, error);
+    console.error("church_geocoding_upstream_error", {
+      error_name: error instanceof Error ? error.name : "UnknownError",
+    });
     return { latitude: null, longitude: null };
   }
 }

--- a/lib/church-evaluation/index.ts
+++ b/lib/church-evaluation/index.ts
@@ -5,6 +5,7 @@ export {
   type TavilyCrawlResult,
 } from "./crawl";
 export {
+  CORE_EXTRACTION_THINKING_LEVEL,
   EVALUATION_MODEL,
   EVALUATION_PROMPT_VERSION,
   extractChurchEvaluation,
@@ -28,3 +29,10 @@ export {
   SUPPORTING_REFORMED_BADGES,
   secondaryDifferenceBadges,
 } from "./policy";
+export {
+  ChurchEvaluationTimeoutError,
+  ChurchEvaluationUpstreamError,
+  logEvaluationStage,
+  measureEvaluationStage,
+  runEvaluationStage,
+} from "./runtime";

--- a/lib/church-evaluation/runtime.test.ts
+++ b/lib/church-evaluation/runtime.test.ts
@@ -1,0 +1,91 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  ChurchEvaluationTimeoutError,
+  runEvaluationStage,
+} from "./runtime";
+
+describe("church evaluation runtime budget", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-28T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("aborts and rejects a stage before its deadline", async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const stage = runEvaluationStage({
+      stage: "gemini_core_doctrines",
+      deadlineAt: Date.now() + 1_000,
+      maxDurationMs: 100,
+      operation: (signal) => {
+        receivedSignal = signal;
+        return new Promise<never>(() => undefined);
+      },
+    });
+    const rejection = expect(stage).rejects.toMatchObject({
+      code: "CHURCH_EVALUATION_TIMEOUT",
+      stage: "gemini_core_doctrines",
+      timeoutMs: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    await rejection;
+    expect(receivedSignal?.aborted).toBe(true);
+    expect(receivedSignal?.reason).toBeInstanceOf(
+      ChurchEvaluationTimeoutError,
+    );
+  });
+
+  it("uses the remaining total budget when it is shorter than the stage limit", async () => {
+    const stage = runEvaluationStage({
+      stage: "tavily_enrichment",
+      deadlineAt: Date.now() + 25,
+      maxDurationMs: 1_000,
+      operation: () => new Promise<never>(() => undefined),
+    });
+    const rejection = expect(stage).rejects.toMatchObject({
+      stage: "tavily_enrichment",
+      timeoutMs: 25,
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
+  });
+
+  it("logs only safe dimensions for a successful stage", async () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    await expect(runEvaluationStage({
+      stage: "tavily_crawl",
+      deadlineAt: Date.now() + 1_000,
+      maxDurationMs: 100,
+      operation: async () => ({ pages: 3 }),
+      dimensions: { inputCharacterCount: 900 },
+      resultDimensions: (result) => ({
+        sourcePageCount: result.pages,
+      }),
+    })).resolves.toEqual({ pages: 3 });
+
+    expect(info).toHaveBeenCalledWith("church_evaluation_stage", {
+      stage: "tavily_crawl",
+      status: "success",
+      elapsed_ms: 0,
+      source_page_count: 3,
+      input_character_count: 900,
+    });
+  });
+});

--- a/lib/church-evaluation/runtime.ts
+++ b/lib/church-evaluation/runtime.ts
@@ -1,0 +1,184 @@
+export const EVALUATION_UPSTREAM_BUDGET_MS = 240_000;
+export const TAVILY_CRAWL_STAGE_TIMEOUT_MS = 80_000;
+export const TAVILY_ENRICHMENT_STAGE_TIMEOUT_MS = 40_000;
+export const GEMINI_STAGE_TIMEOUT_MS = 55_000;
+
+export type EvaluationStageDimensions = {
+  sourcePageCount?: number;
+  inputCharacterCount?: number;
+};
+
+type EvaluationStageStatus = "success" | "error" | "timeout";
+
+export class ChurchEvaluationTimeoutError extends Error {
+  readonly code = "CHURCH_EVALUATION_TIMEOUT";
+
+  constructor(
+    readonly stage: string,
+    readonly timeoutMs: number,
+  ) {
+    super(`Church evaluation timed out during ${stage}.`);
+    this.name = "ChurchEvaluationTimeoutError";
+  }
+}
+
+export class ChurchEvaluationUpstreamError extends Error {
+  readonly code = "CHURCH_EVALUATION_UPSTREAM_ERROR";
+
+  constructor(
+    readonly provider: "gemini" | "tavily",
+    readonly stage: string,
+    options?: ErrorOptions,
+  ) {
+    super(`Church evaluation upstream request failed during ${stage}.`, options);
+    this.name = "ChurchEvaluationUpstreamError";
+  }
+}
+
+export function createEvaluationDeadline(
+  budgetMs = EVALUATION_UPSTREAM_BUDGET_MS,
+): number {
+  return Date.now() + budgetMs;
+}
+
+export function logEvaluationStage({
+  stage,
+  status,
+  startedAt,
+  dimensions = {},
+  error,
+}: {
+  stage: string;
+  status: EvaluationStageStatus;
+  startedAt: number;
+  dimensions?: EvaluationStageDimensions;
+  error?: unknown;
+}): void {
+  console.info("church_evaluation_stage", {
+    stage,
+    status,
+    elapsed_ms: Math.max(0, Date.now() - startedAt),
+    ...(dimensions.sourcePageCount === undefined
+      ? {}
+      : { source_page_count: dimensions.sourcePageCount }),
+    ...(dimensions.inputCharacterCount === undefined
+      ? {}
+      : { input_character_count: dimensions.inputCharacterCount }),
+    ...(error instanceof Error ? { error_name: error.name } : {}),
+  });
+}
+
+export async function measureEvaluationStage<T>({
+  stage,
+  operation,
+  dimensions,
+  resultDimensions,
+}: {
+  stage: string;
+  operation: () => T | Promise<T>;
+  dimensions?: EvaluationStageDimensions;
+  resultDimensions?: (result: T) => EvaluationStageDimensions;
+}): Promise<T> {
+  const startedAt = Date.now();
+
+  try {
+    const result = await operation();
+    logEvaluationStage({
+      stage,
+      status: "success",
+      startedAt,
+      dimensions: {
+        ...dimensions,
+        ...resultDimensions?.(result),
+      },
+    });
+    return result;
+  } catch (error) {
+    logEvaluationStage({
+      stage,
+      status: "error",
+      startedAt,
+      dimensions,
+      error,
+    });
+    throw error;
+  }
+}
+
+export async function runEvaluationStage<T>({
+  stage,
+  deadlineAt,
+  maxDurationMs,
+  operation,
+  dimensions,
+  resultDimensions,
+}: {
+  stage: string;
+  deadlineAt: number;
+  maxDurationMs: number;
+  operation: (signal: AbortSignal) => Promise<T>;
+  dimensions?: EvaluationStageDimensions;
+  resultDimensions?: (result: T) => EvaluationStageDimensions;
+}): Promise<T> {
+  const startedAt = Date.now();
+  const timeoutMs = Math.min(
+    maxDurationMs,
+    Math.max(0, deadlineAt - startedAt),
+  );
+
+  if (timeoutMs === 0) {
+    const error = new ChurchEvaluationTimeoutError(stage, timeoutMs);
+    logEvaluationStage({
+      stage,
+      status: "timeout",
+      startedAt,
+      dimensions,
+      error,
+    });
+    throw error;
+  }
+
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const error = new ChurchEvaluationTimeoutError(stage, timeoutMs);
+      controller.abort(error);
+      reject(error);
+    }, timeoutMs);
+  });
+
+  try {
+    const result = await Promise.race([
+      operation(controller.signal),
+      timeoutPromise,
+    ]);
+    logEvaluationStage({
+      stage,
+      status: "success",
+      startedAt,
+      dimensions: {
+        ...dimensions,
+        ...resultDimensions?.(result),
+      },
+    });
+    return result;
+  } catch (error) {
+    const normalizedError = controller.signal.aborted &&
+        controller.signal.reason instanceof ChurchEvaluationTimeoutError
+      ? controller.signal.reason
+      : error;
+    logEvaluationStage({
+      stage,
+      status: normalizedError instanceof ChurchEvaluationTimeoutError
+        ? "timeout"
+        : "error",
+      startedAt,
+      dimensions,
+      error: normalizedError,
+    });
+    throw normalizedError;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/lib/prompts/church-finder.test.ts
+++ b/lib/prompts/church-finder.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BASIC_FIELDS_PROMPT,
+  CORE_DOCTRINES_PROMPT,
+  DENOMINATION_CONFESSION_PROMPT,
+  RED_FLAGS_PROMPT,
+  SECONDARY_DOCTRINES_PROMPT,
+  TERTIARY_DOCTRINES_PROMPT,
+} from "./church-finder";
+
+const extractionPrompts = [
+  BASIC_FIELDS_PROMPT,
+  CORE_DOCTRINES_PROMPT,
+  SECONDARY_DOCTRINES_PROMPT,
+  TERTIARY_DOCTRINES_PROMPT,
+  DENOMINATION_CONFESSION_PROMPT,
+  RED_FLAGS_PROMPT,
+];
+
+describe("church finder multilingual prompt contract", () => {
+  it("applies source-language semantics and original quotations to every call", () => {
+    for (const prompt of extractionPrompts) {
+      expect(prompt).toContain(
+        "Analyze official church content semantically in whatever language it is written.",
+      );
+      expect(prompt).toContain(
+        "required canonical English form even when the source content is not English",
+      );
+      expect(prompt).toContain(
+        "Preserve evidence quotations exactly in their original source language.",
+      );
+      expect(prompt).toContain(
+        "not an explanation, translation, or paraphrase",
+      );
+    }
+  });
+
+  it("requires complete semantic evidence for composite core doctrines", () => {
+    expect(CORE_DOCTRINES_PROMPT).toContain(
+      "`\"true\"` requires explicit evidence for EVERY required component",
+    );
+    expect(CORE_DOCTRINES_PROMPT).toContain(
+      "If only part of a composite doctrine is stated, return `\"unknown\"`.",
+    );
+    expect(CORE_DOCTRINES_PROMPT).toContain(
+      "return multiple notes with the same doctrine label",
+    );
+  });
+
+  it("keeps same-person clergy and textual-gender safeguards in the model contract", () => {
+    expect(RED_FLAGS_PROMPT).toContain(
+      "the same specifically named person is explicitly connected to both",
+    );
+    expect(RED_FLAGS_PROMPT).toContain(
+      "source-language gendered title or honorific, pronoun, grammatical gender signal",
+    );
+    expect(RED_FLAGS_PROMPT).toContain(
+      "Do not infer gender from a first name or photograph.",
+    );
+    expect(RED_FLAGS_PROMPT).toContain(
+      "couple listing, generic leadership heading, wife relationship, or non-clergy role",
+    );
+    expect(RED_FLAGS_PROMPT).toContain(
+      "the one exact original-language quotation must connect the same named person",
+    );
+  });
+
+  it("requires groundable quotations instead of synthesized note explanations", () => {
+    expect(DENOMINATION_CONFESSION_PROMPT).toContain(
+      "One short verbatim original-language quotation that explicitly shows adoption",
+    );
+    expect(RED_FLAGS_PROMPT).toContain(
+      "do not add explanatory framing",
+    );
+    expect(RED_FLAGS_PROMPT).not.toContain(
+      "`text`: Brief explanation of what you found",
+    );
+  });
+});

--- a/lib/prompts/church-finder.ts
+++ b/lib/prompts/church-finder.ts
@@ -11,11 +11,14 @@ STRICT OUTPUT:
 - Return JSON only that conforms exactly to the provided schema for this call.
 - Do not include Markdown, explanations, comments, or extra keys not in the schema.
 - Use absolute URLs from the provided content when populating any URL field.
+- Keep all schema keys, doctrine statuses, and allowed badge labels in their required canonical English form even when the source content is not English.
 
 EVIDENCE AND CONSERVATISM:
+- Analyze official church content semantically in whatever language it is written. Never require an English keyword, URL word, office title, honorific, pronoun, or phrase to recognize a concept.
 - Work only from the provided pages. Never invent or infer beyond explicit statements.
 - If a value is not clearly stated, return \`null\` (or \`"unknown"\` for doctrine booleans).
-- Quotes in notes must be short, verbatim excerpts from the page, not paraphrases.
+- Every \`notes[].text\` value must be only one short verbatim excerpt from the cited page, not an explanation, translation, or paraphrase.
+- Preserve evidence quotations exactly in their original source language. Do not translate them into English.
 
 DEDUPLICATION & HYGIENE:
 - Deduplicate arrays (addresses, service_times, badges). Keep the clearest single representation.
@@ -67,6 +70,7 @@ Extract the following fields from the website content:
   - \`leadership\`: Elders / staff / team / leadership page
 
 ADDITIONAL GUIDANCE:
+- Choose pages by their semantic content in the source language, not by English words in the URL or page title.
 - Prefer “Contact/Visit/Plan Your Visit” pages for addresses when available; avoid map widgets without text unless they clearly display a postal address.
 - Exclude P.O. Boxes if a physical address is available; if only a P.O. Box is present, include it.
 - For leadership, prefer pages listing elders/pastors over general staff directories.
@@ -105,6 +109,7 @@ Set each to \`"true"\`, \`"false"\`, or \`"unknown"\`:
 - \`"true"\`: Church explicitly affirms this doctrine (see definitions above for what counts as affirmation)
 - \`"false"\`: Church explicitly denies or contradicts this doctrine
 - \`"unknown"\`: Not clearly stated or ambiguous
+- Interpret the doctrine definitions semantically in the source language. English terminology in these instructions is descriptive, not a required keyword list.
 - For a doctrine whose name or definition combines multiple claims, \`"true"\` requires explicit evidence for EVERY required component. Do not award partial credit by treating one component as the entire doctrine.
 - Evidence may be combined across official pages, but every required component must be supported by a source-grounded note. If only part of a composite doctrine is stated, return \`"unknown"\`.
 - Do not reuse a broad sentence to affirm several doctrines unless that sentence independently satisfies every definition in full.
@@ -239,6 +244,8 @@ export const DENOMINATION_CONFESSION_PROMPT = `${COMMON_RULES}
 **Confession:**
 Determine if the church **adopts** a historic confession as their doctrinal standard.
 
+Interpret adoption language semantically in the source language. The English examples below are illustrations only; equivalent statements in any language count, and no English wording is required.
+
 **Mark \`adopted = true\` if you find ANY of these indicators:**
 
 1. **Direct adoption language:**
@@ -340,13 +347,12 @@ STRICT BADGE OUTPUT RULES:
 **Notes:**
 If \`adopted = true\`, add a note:
 - \`label\`: "Adopted Confession"
-- \`text\`: "Church adopts [confession name] as their doctrinal standard"
-- \`source_url\`: URL where you found this
- - If the church qualifies the adoption (e.g., "subscribe for guidance but not absolute adherence"), include that nuance in the note text (short summary ≤30 words) in addition to the adoption label, e.g. "Church subscribes to [confession name] for guidance (not absolute adherence)".
+- \`text\`: One short verbatim original-language quotation that explicitly shows adoption, including any qualification in the source wording
+- \`source_url\`: URL containing that exact quotation
 If "🤝 Denomination/Network Affiliated" badge is present, add a note:
 - \`label\`: "Denomination Affiliation" OR "Network Affiliation" (use "Network Affiliation" for fellowships/networks like FIRE, Acts 29, ARBCA; use "Denomination Affiliation" for traditional denominations like PCA, SBC)
-- \`text\`: "Church is affiliated with [denomination/network name]" (include a brief description if provided, e.g., "Church is a member of FIRE (Fellowship of Independent Reformed Evangelicals), a network for independent Reformed baptistic churches")
-- \`source_url\`: URL where you found this
+- \`text\`: One short verbatim original-language quotation that explicitly states the affiliation
+- \`source_url\`: URL containing that exact quotation
 
 Only add badges you have clear evidence for. Return empty array if none apply.`;
 
@@ -397,15 +403,16 @@ Add badges ONLY if you have clear evidence, including the emoji. If none of the 
 - **NOTE**: Youth and children's ministries naturally use engaging methods (games, activities, creative lessons) to reach their age group. Only flag if the church's MAIN worship services show entertainment-driven compromise, not based solely on youth/children's ministry descriptions.
 
 **👩‍🏫 Ordained Women**:
-- Add this badge ONLY when a specific individual woman is explicitly described with an ordained/clergy office title such as **Pastor**, **Elder**, **Reverend/Rev.**, **Bishop**, or **Priest**.
+- Apply these rules semantically in the source language. The English titles and examples below illustrate qualifying clergy offices but are never required keywords.
+- Add this badge ONLY when the same specifically named person is explicitly connected to both (1) a qualifying ordained/clergy office such as pastor, elder, reverend, bishop, or priest and (2) explicit textual female identity.
 - This is about the woman's *office/title*, not about general church governance language.
-- Require explicit textual evidence that the named officeholder is a woman, such as Ms./Mrs./Miss, "(she/her)", or a directly connected "She/Her" biographical statement. Do not infer gender from a first name or photograph.
+- Textual female identity may be established by a source-language gendered title or honorific, pronoun, grammatical gender signal, or explicit statement that clearly refers to that same named officeholder. Do not infer gender from a first name or photograph.
 - The office title must be directly attached to the specific woman's name. A generic "Elders/Pastors" section heading above couples or families is not enough.
 - Do NOT infer that a pastor's or elder's wife holds office because a couple is shown together or because elders/pastors "serve together alongside their wives."
 - NOT for women serving as deacons/deaconesses, staff, ministry leaders/directors, committee members, board/council roles, or teachers in non-governing roles.
 - Do NOT infer this badge from phrases like "elder-led" / "elder-directed" / "elder-governed" unless the page explicitly lists women as elders.
 - Do NOT infer this badge from "Chair" / "Vice-Chair" / "Secretary" / "Treasurer" unless the page explicitly identifies that woman as an Elder/Pastor/Rev/Bishop/Priest.
-- Look for explicit titles like: "Pastor [Woman's name]", "[Woman's name] — Pastor of ___", "Elder [Woman's name]", "Rev. [Woman's name]", "Bishop [Woman's name]", "Priest [Woman's name]".
+- Source-language forms equivalent to "Pastor [Woman's name]", "[Woman's name] — Pastor of ___", "Elder [Woman's name]", "Rev. [Woman's name]", "Bishop [Woman's name]", or "Priest [Woman's name]" qualify only when the same-person textual female-identity requirement is also met.
 - **IMPORTANT**: If you see "[Woman's Name] - Pastor of [any ministry area]" under "Pastoral Staff" → ADD THIS BADGE.
 - **CRITICAL false-positive guard**: If women are listed under "Deacons and Deaconesses" / "Deaconesses" / "Deaconess" (or similar) WITHOUT an Elder/Pastor/Rev/Bishop/Priest title, DO NOT add this badge.
 - Examples that MUST trigger this badge:
@@ -471,9 +478,9 @@ Examples that DO NOT count (omit the badge):
 ### Notes:
 For each red flag badge you add, create a note with:
 - \`label\`: Name of the badge (e.g., "Prosperity Gospel", "LGBTQ Affirming", "New Apostolic Reformation (NAR)")
-- \`text\`: Brief explanation of what you found (≤50 words)
-- \`source_url\`: URL where you found this evidence
+- \`text\`: One short verbatim quotation in the original source language that directly establishes the badge; do not add explanatory framing
+- \`source_url\`: URL containing that exact quotation
 
-For the **👩‍🏫 Ordained Women** badge specifically, your note text MUST include one exact quotation containing both the woman's explicit office title and textual female-identity evidence (e.g., "Sarah Johnson — Pastor of Children's Ministry. She oversees..."). If the site gives only a name/title or photograph without Ms./Mrs./Miss, she/her pronouns, or another explicit textual female signal, DO NOT add the badge.
+For the **👩‍🏫 Ordained Women** badge specifically, the one exact original-language quotation must connect the same named person to both the qualifying clergy office and textual female identity. If the site gives only a name/title, photograph, couple listing, generic leadership heading, wife relationship, or non-clergy role, DO NOT add the badge.
 
 If NO red flags are found, return empty arrays for both badges and notes.`;

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
 
 const shadowDatabaseUrl = process.env.SHADOW_DATABASE_URL;
 
@@ -10,7 +10,7 @@ export default defineConfig({
     seed: "node prisma/seed.mjs",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env.DATABASE_URL ?? "",
     ...(shadowDatabaseUrl ? { shadowDatabaseUrl } : {}),
   },
 });


### PR DESCRIPTION
Closes #80

## Summary

- Make deterministic evidence validation language-neutral while preserving fail-closed URL and verbatim-quotation grounding.
- Move doctrine completeness and same-person clergy/gender semantics into multilingual structured prompts, and remove the English URL-discovery prepass.
- Migrate the evaluator to Gemini 3.6 Flash with medium core-doctrine thinking and versioned evaluation metadata.
- Add bounded Tavily/Gemini stages, safe latency telemetry, a 300-second route duration, and controlled 502/504 responses.
- Move non-critical geocoding to Next.js `after()` while keeping evaluation and persistence awaited.
- Fix Prisma's postinstall bootstrap when `DATABASE_URL` has not yet been generated for a new Codex worktree.

## Root cause

The local setup failed because `env("DATABASE_URL")` threw during `npm ci`'s Prisma postinstall before the worktree environment could generate its database URL. The church evaluator also mixed deterministic provenance validation with English semantic regex gates, had no realistic per-stage/function time budget, and launched geocoding as unregistered fire-and-forget work.

## Validation

- `npm test` — 119 passed, 3 skipped
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Representative Spanish evaluation: HTTP 200 in 50.95 seconds across 5 source pages; Gemini 3.6 metadata persisted, original-language evidence retained, and background geocoding completed.
- Original Refuge timeout reproduction: HTTP 200 in 39.7 seconds across 9 source pages; every evaluation stage, persistence, and background geocoding succeeded.